### PR TITLE
chore: rename package to apermo-coding-standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,8 +144,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCompatibility checks targeting PHP 8.3+.
 - Empty `Apermo/Sniffs/` directory for future custom sniffs.
 
-[1.3.0]: https://github.com/apermo/wp-coding-standards/compare/v1.2.1...v1.3.0
-[1.2.1]: https://github.com/apermo/wp-coding-standards/compare/v1.2.0...v1.2.1
-[1.2.0]: https://github.com/apermo/wp-coding-standards/compare/v1.1.0...v1.2.0
-[1.1.0]: https://github.com/apermo/wp-coding-standards/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/apermo/wp-coding-standards/releases/tag/v1.0.0
+[1.3.0]: https://github.com/apermo/apermo-coding-standards/compare/v1.2.1...v1.3.0
+[1.2.1]: https://github.com/apermo/apermo-coding-standards/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/apermo/apermo-coding-standards/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/apermo/apermo-coding-standards/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/apermo/apermo-coding-standards/releases/tag/v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,14 @@
-# CLAUDE.md — apermo/wp-coding-standards
+# CLAUDE.md — apermo/apermo-coding-standards
 
 Shared PHPCS coding standards package for WordPress projects by Apermo.
 
-GitHub: https://github.com/apermo/wp-coding-standards
+GitHub: https://github.com/apermo/apermo-coding-standards
 
 ## Overview
 
 This is a `phpcodesniffer-standard` Composer package. It provides a reusable PHPCS ruleset (`Apermo`) that combines WordPress Coding Standards, Slevomat type hints, YoastCS, and PHPCompatibility.
 
-Projects consume it by requiring `apermo/wp-coding-standards` and referencing `<rule ref="Apermo"/>` in their `phpcs.xml`.
+Projects consume it by requiring `apermo/apermo-coding-standards` and referencing `<rule ref="Apermo"/>` in their `phpcs.xml`.
 
 ## Package Structure
 
@@ -53,4 +53,4 @@ vendor/bin/phpcs -i
 
 1. Commit changes, push to `main`
 2. Tag a release: `git tag v1.0.0 && git push --tags`
-3. Consumer projects update via `composer update apermo/wp-coding-standards`
+3. Consumer projects update via `composer update apermo/apermo-coding-standards`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apermo WordPress Coding Standards
 
-[![CI](https://github.com/apermo/wp-coding-standards/actions/workflows/ci.yml/badge.svg)](https://github.com/apermo/wp-coding-standards/actions/workflows/ci.yml)
+[![CI](https://github.com/apermo/apermo-coding-standards/actions/workflows/ci.yml/badge.svg)](https://github.com/apermo/apermo-coding-standards/actions/workflows/ci.yml)
 
 Shared [PHPCS](https://github.com/PHPCSStandards/PHP_CodeSniffer) ruleset for WordPress projects. Combines WordPress Coding Standards, Slevomat type hints, YoastCS, and PHPCompatibility into a single reusable standard.
 
@@ -17,14 +17,14 @@ Add the GitHub repository and require the package:
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/apermo/wp-coding-standards"
+            "url": "https://github.com/apermo/apermo-coding-standards"
         }
     ]
 }
 ```
 
 ```bash
-composer require --dev apermo/wp-coding-standards
+composer require --dev apermo/apermo-coding-standards
 ```
 
 The [Composer Installer Plugin](https://github.com/PHPCSStandards/composer-installer) automatically registers the standard with PHPCS.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "apermo/wp-coding-standards",
+	"name": "apermo/apermo-coding-standards",
 	"description": "Shared PHPCS coding standards for WordPress projects by Apermo.",
 	"version": "1.3.0",
 	"type": "phpcodesniffer-standard",
@@ -10,10 +10,10 @@
 			"homepage": "https://christoph-daum.de"
 		}
 	],
-	"homepage": "https://github.com/apermo/wp-coding-standards",
+	"homepage": "https://github.com/apermo/apermo-coding-standards",
 	"support": {
-		"issues": "https://github.com/apermo/wp-coding-standards/issues",
-		"source": "https://github.com/apermo/wp-coding-standards"
+		"issues": "https://github.com/apermo/apermo-coding-standards/issues",
+		"source": "https://github.com/apermo/apermo-coding-standards"
 	},
 	"keywords": ["phpcs", "wordpress", "coding-standards", "static-analysis"],
 	"require": {


### PR DESCRIPTION
## Summary

- Rename Composer package from `apermo/wp-coding-standards` to `apermo/apermo-coding-standards`
- Update all references in README, CLAUDE.md, CHANGELOG.md, and composer.json to match the new repository name