### PR TITLE
docs: add changelog for v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.1] - 2026-02-19
+
+### Changed
+
+- Rename Composer package from `apermo/wp-coding-standards`
+  to `apermo/apermo-coding-standards`.
+- Update all repository URLs in README, CLAUDE.md, and
+  CHANGELOG to match the new package name.
 
 ## [1.3.0] - 2026-02-16
 
@@ -144,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCompatibility checks targeting PHP 8.3+.
 - Empty `Apermo/Sniffs/` directory for future custom sniffs.
 
+[1.3.1]: https://github.com/apermo/apermo-coding-standards/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/apermo/apermo-coding-standards/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/apermo/apermo-coding-standards/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/apermo/apermo-coding-standards/compare/v1.1.0...v1.2.0

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "apermo/apermo-coding-standards",
 	"description": "Shared PHPCS coding standards for WordPress projects by Apermo.",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"type": "phpcodesniffer-standard",
 	"license": "MIT",
 	"authors": [


### PR DESCRIPTION
## Summary

- Add missing CHANGELOG entry for the package rename from `apermo/wp-coding-standards` to `apermo/apermo-coding-standards`
- Bump version to 1.3.1 in `composer.json`