### PR TITLE
fix: use branch name for PR lookup in both workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          PR_NUMBER=$(gh pr list --state merged --search "${{ github.sha }}" --json number --jq '.[0].number')
+          VERSION="${{ steps.version.outputs.version }}"
+          PR_NUMBER=$(gh pr list --state merged --head "release/$VERSION" --json number --jq '.[0].number')
           if [ -n "$PR_NUMBER" ]; then
             gh pr comment "$PR_NUMBER" --body "Draft release created: ${{ steps.create-release.outputs.url }}"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Release-published workflow now finds the merged PR by
-  branch name (`release/$VERSION`) instead of search query.
+- Release and release-published workflows now find the
+  merged PR by branch name (`release/$VERSION`) instead
+  of SHA or tag search queries.
 
 ## [2.0.1] - 2026-02-21
 


### PR DESCRIPTION
## Summary

- Fix PR lookup in `release.yml` — same bug as #25 but in the "Comment on merged PR" step
- `release-published.yml` fix already merged in #33

Both workflows now use `--head "release/$VERSION"` instead of SHA/tag search queries.

## Test plan

- [ ] Merge, verify "Draft release created" comment appears on this PR
- [ ] Publish the draft, verify "Released" comment appears

Closes #25