### PR TITLE
Release 2.6.2

### DIFF
--- a/Apermo/ruleset.xml
+++ b/Apermo/ruleset.xml
@@ -27,6 +27,8 @@
 		<exclude name="WordPress.PHP.YodaConditions"/>
 		<!-- We enforce post-increment, not pre-increment. -->
 		<exclude name="Universal.Operators.DisallowStandalonePostIncrementDecrement"/>
+		<!-- Suggests pre-increment; conflicts with DisallowPreIncrementDecrement. -->
+		<exclude name="Squiz.Operators.IncrementDecrementUsage"/>
 		<!-- We allow short open tags. -->
 		<exclude name="Generic.PHP.DisallowShortOpenTag.EchoFound"/>
 		<!-- We allow short open tags. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.2] - Unreleased
+
+### Fixed
+
+- Excluded `Squiz.Operators.IncrementDecrementUsage` from WordPress
+  block. The sniff suggests pre-increment (`++$var`) for patterns
+  like `$var = $var + 1`, conflicting with our post-increment
+  preference enforced by `DisallowPreIncrementDecrement`.
+
 ## [2.6.1] - 2026-03-15
 
 ### Added
@@ -381,6 +390,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCompatibility checks targeting PHP 8.3+.
 - Empty `Apermo/Sniffs/` directory for future custom sniffs.
 
+[2.6.2]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.1...v2.6.2
 [2.6.1]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.4.0...v2.5.0

--- a/tests/Integration/Fixtures/IncrementDecrement.inc
+++ b/tests/Integration/Fixtures/IncrementDecrement.inc
@@ -6,15 +6,20 @@
 // phpcs:disable Apermo.CodeQuality
 // phpcs:enable SlevomatCodingStandard.Operators.RequireOnlyStandaloneIncrementAndDecrementOperators
 // phpcs:enable Apermo.Operators.DisallowPreIncrementDecrement
+// phpcs:enable Squiz.Operators.IncrementDecrementUsage
 $a = 1;
 $b = 1;
-// Pre-increment — flagged by custom sniff (line 12).
+// Pre-increment — flagged by custom sniff (line 13).
 ++$a;
-// Post-increment standalone — allowed (line 14).
+// Post-increment standalone — allowed (line 15).
 $a++;
-// Post-increment in for — allowed (line 16).
+// Post-increment in for — allowed (line 17).
 for ( $i = 0; $i < 10; $i++ ) { $a++; }
-// Non-standalone: assignment with increment — flagged by Slevomat (line 18).
+// Non-standalone: assignment with increment — flagged by Slevomat (line 19).
 $b = $a++;
-// Post-decrement standalone — allowed (line 20).
+// Post-decrement standalone — allowed (line 21).
 $a--;
+// Manual increment — should not suggest pre-increment (line 23).
+$a = $a + 1;
+// Manual decrement — should not suggest pre-decrement (line 25).
+$a = $a - 1;

--- a/tests/Integration/RulesetIntegrationTest.php
+++ b/tests/Integration/RulesetIntegrationTest.php
@@ -427,11 +427,13 @@ class RulesetIntegrationTest extends TestCase {
 
 	public function testIncrementDecrementEnforcement(): void {
 		$file = $this->processFixture( 'IncrementDecrement.inc' );
-		$this->assertErrorOnLine( $file, 12, 'PreIncrementFound', 'Pre-increment should be flagged.' );
-		$this->assertNoErrorsOnLine( $file, 14, 'Standalone post-increment should be allowed.' );
-		$this->assertNoErrorsOnLine( $file, 16, 'Post-increment in for() should be allowed.' );
-		$this->assertErrorOnLine( $file, 18, 'RequireOnlyStandaloneIncrementAndDecrementOperators', 'Non-standalone increment should be flagged.' );
-		$this->assertNoErrorsOnLine( $file, 20, 'Post-decrement standalone should be allowed.' );
+		$this->assertErrorOnLine( $file, 13, 'PreIncrementFound', 'Pre-increment should be flagged.' );
+		$this->assertNoErrorsOnLine( $file, 15, 'Standalone post-increment should be allowed.' );
+		$this->assertNoErrorsOnLine( $file, 17, 'Post-increment in for() should be allowed.' );
+		$this->assertErrorOnLine( $file, 19, 'RequireOnlyStandaloneIncrementAndDecrementOperators', 'Non-standalone increment should be flagged.' );
+		$this->assertNoErrorsOnLine( $file, 21, 'Post-decrement standalone should be allowed.' );
+		$this->assertNoErrorsOnLine( $file, 23, 'Manual increment should not suggest pre-increment.' );
+		$this->assertNoErrorsOnLine( $file, 25, 'Manual decrement should not suggest pre-decrement.' );
 	}
 
 	public function testClassStructure(): void {


### PR DESCRIPTION
## Summary

- Exclude `Squiz.Operators.IncrementDecrementUsage` from WordPress block — it suggests
  pre-increment (`++$var`) for `$var = $var + 1` patterns, conflicting with
  `DisallowPreIncrementDecrement`

Closes #83

## Test plan

- [x] Integration test covers `$a = $a + 1` / `$a = $a - 1` no longer triggering errors
- [x] Full test suite passes (70 tests, 174 assertions)
- [x] `Squiz.Operators.IncrementDecrementUsage` no longer in active sniff list