### PR TITLE
Release 2.6.3

### DIFF
--- a/Apermo/Sniffs/Hooks/RequireHookDocBlockSniff.php
+++ b/Apermo/Sniffs/Hooks/RequireHookDocBlockSniff.php
@@ -130,6 +130,7 @@ class RequireHookDocBlockSniff implements Sniff {
 		$tokens     = $phpcsFile->getTokens();
 		$paramCount = 0;
 		$hasReturn  = false;
+		$hasSee     = false;
 
 		for ( $i = $docBlock['open']; $i <= $docBlock['close']; $i++ ) {
 			if ( $tokens[ $i ]['code'] === T_DOC_COMMENT_TAG ) {
@@ -138,8 +139,15 @@ class RequireHookDocBlockSniff implements Sniff {
 					$paramCount++;
 				} elseif ( $tagContent === '@return' ) {
 					$hasReturn = true;
+				} elseif ( $tagContent === '@see' ) {
+					$hasSee = true;
 				}
 			}
+		}
+
+		// @see indicates the hook is documented elsewhere (e.g. WP core).
+		if ( $hasSee ) {
+			return;
 		}
 
 		$hookArgs = $this->countHookArguments( $phpcsFile, $stackPtr, $funcName );

--- a/Apermo/Tests/Hooks/RequireHookDocBlockUnitTest.inc
+++ b/Apermo/Tests/Hooks/RequireHookDocBlockUnitTest.inc
@@ -102,3 +102,12 @@ do_action_deprecated( 'my_spaced_deprecated', array(), '2.0.0', 'my_new' );
  * OK: ref_array with long syntax array() no spaces.
  */
 do_action_ref_array( 'my_long_action', array() );
+
+/** @see wp-includes/post-template.php the_content() */
+apply_filters( 'the_content', $content );
+
+/** @see wp-includes/plugin.php do_action() */
+do_action( 'init', $arg1, $arg2 );
+
+/** @see wp-includes/post.php wp_insert_post() */
+apply_filters_ref_array( 'wp_insert_post_data', $data );

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.6.2] - Unreleased
+## [2.6.3] - Unreleased
+
+### Fixed
+
+- `Apermo.Hooks.RequireHookDocBlock`: accept `@see` as valid
+  documentation for hooks documented elsewhere (e.g. WP core).
+  A doc block with `@see` no longer requires `@param`/`@return`.
+
+## [2.6.2] - 2026-03-22
 
 ### Fixed
 
@@ -390,6 +398,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCompatibility checks targeting PHP 8.3+.
 - Empty `Apermo/Sniffs/` directory for future custom sniffs.
 
+[2.6.3]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.2...v2.6.3
 [2.6.2]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.1...v2.6.2
 [2.6.1]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.5.0...v2.6.0


### PR DESCRIPTION
## Summary

- `RequireHookDocBlock`: accept `@see` as valid documentation for hooks
  documented elsewhere (e.g. WP core). A doc block with `@see` skips
  `@param`/`@return` validation.

Closes #88

## Test plan

- [x] Unit test covers `@see` on `apply_filters`, `do_action`, and `apply_filters_ref_array`
- [x] Full test suite passes (70 tests, 174 assertions)
- [x] PHPStan clean