### PR TITLE
feat: 2.6.4 improvements

### DIFF
--- a/Apermo/Sniffs/NamingConventions/MinimumVariableNameLengthSniff.php
+++ b/Apermo/Sniffs/NamingConventions/MinimumVariableNameLengthSniff.php
@@ -35,16 +35,19 @@ class MinimumVariableNameLengthSniff implements Sniff {
 	public array $allowedShortNames = [
 		'i',
 		'id',
+		'ids',
+		'ip',
 		'key',
-		'url',
-		'row',
-		'tag',
 		'map',
 		'max',
 		'min',
-		'sql',
 		'raw',
-		'ids',
+		'row',
+		'sql',
+		'tag',
+		'ttl',
+		'uri',
+		'url',
 	];
 
 	/**

--- a/Apermo/Sniffs/WordPress/ImplicitPostFunctionSniff.php
+++ b/Apermo/Sniffs/WordPress/ImplicitPostFunctionSniff.php
@@ -42,6 +42,7 @@ class ImplicitPostFunctionSniff extends AbstractPostContextSniff {
 	private const POST_FUNCTIONS = [
 		// Functions with a $post parameter.
 		'get_post'                          => [ 'position' => 1, 'name' => 'post' ],
+		'get_post_format'                   => [ 'position' => 1, 'name' => 'post' ],
 		'get_the_title'                     => [ 'position' => 1, 'name' => 'post' ],
 		'get_the_excerpt'                   => [ 'position' => 1, 'name' => 'post' ],
 		'get_permalink'                     => [ 'position' => 1, 'name' => 'post' ],

--- a/Apermo/ruleset.xml
+++ b/Apermo/ruleset.xml
@@ -135,6 +135,24 @@
 	<!-- Disallow Yoda conditions. -->
 	<rule ref="Generic.ControlStructures.DisallowYodaConditions"/>
 
+	<!-- Boolean operators must appear at the start of the line in multi-line conditions. -->
+	<rule ref="PSR12.ControlStructures.BooleanOperatorPlacement">
+		<properties>
+			<property name="allowOnly" value="first"/>
+		</properties>
+	</rule>
+
+	<!-- Each condition part must be on its own line, operator at start of next line. -->
+	<rule ref="SlevomatCodingStandard.ControlStructures.RequireMultiLineCondition">
+		<properties>
+			<property name="alwaysSplitAllConditionParts" value="true"/>
+			<property name="booleanOperatorOnPreviousLine" value="false"/>
+		</properties>
+	</rule>
+
+	<!-- Require parentheses when mixing && and || to clarify precedence. -->
+	<rule ref="Generic.CodeAnalysis.RequireExplicitBooleanOperatorPrecedence"/>
+
 	<!-- Enforce concatenation operators at start of line in multi-line. -->
 	<rule ref="Universal.Operators.ConcatPosition"/>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.4] - Unreleased
+
+### Added
+
+- `PSR12.ControlStructures.BooleanOperatorPlacement`: enforce
+  boolean operators at the start of continuation lines in
+  multi-line conditions. Auto-fixable.
+- `SlevomatCodingStandard.ControlStructures.RequireMultiLineCondition`:
+  require one condition per line in multi-line conditions.
+  Auto-fixable.
+- `Generic.CodeAnalysis.RequireExplicitBooleanOperatorPrecedence`:
+  require parentheses when mixing `&&` and `||`.
+- `ip`, `ttl`, `uri` added to `MinimumVariableNameLength`
+  default allowlist.
+- `get_post_format` added to `ImplicitPostFunction` sniff.
+
 ## [2.6.3] - Unreleased
 
 ### Fixed
@@ -398,6 +414,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCompatibility checks targeting PHP 8.3+.
 - Empty `Apermo/Sniffs/` directory for future custom sniffs.
 
+[2.6.4]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.3...v2.6.4
 [2.6.3]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.2...v2.6.3
 [2.6.2]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.1...v2.6.2
 [2.6.1]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.0...v2.6.1

--- a/tests/Integration/Fixtures/BooleanOperators.inc
+++ b/tests/Integration/Fixtures/BooleanOperators.inc
@@ -1,0 +1,59 @@
+<?php
+// phpcs:disable WordPress,Squiz,PSR1,SlevomatCodingStandard.TypeHints,SlevomatCodingStandard.Functions
+// phpcs:disable SlevomatCodingStandard.Variables,SlevomatCodingStandard.Namespaces,SlevomatCodingStandard.Classes
+// phpcs:disable SlevomatCodingStandard.Complexity,SlevomatCodingStandard.Arrays,SlevomatCodingStandard.Operators
+// phpcs:disable SlevomatCodingStandard.PHP,SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator
+// phpcs:disable Generic.Arrays,Generic.PHP,Generic.Formatting,Generic.ControlStructures,Generic.WhiteSpace
+// phpcs:disable PSR2,PSR12.Classes,PSR12.Files,PSR12.Namespaces,PSR12.Properties,PSR12.Keywords
+// phpcs:disable PEAR,Universal,Apermo
+
+$a = true;
+$b = false;
+$c = true;
+
+// Operator at end of line — should be flagged (line 15).
+if (
+	$a &&
+	$b
+) {
+	echo 1;
+}
+
+// Operator at start of line — should be allowed (line 23).
+if (
+	$a
+	&& $b
+) {
+	echo 1;
+}
+
+// Multi-line condition not fully split — should be flagged (line 31).
+// phpcs:disable PSR12.ControlStructures.BooleanOperatorPlacement
+// phpcs:disable Generic.CodeAnalysis.RequireExplicitBooleanOperatorPrecedence
+if (
+	$a && $b
+	&& $c
+) {
+	echo 1;
+}
+// phpcs:enable Generic.CodeAnalysis.RequireExplicitBooleanOperatorPrecedence
+// phpcs:enable PSR12.ControlStructures.BooleanOperatorPlacement
+
+// Multi-line fully split — should be allowed (line 43).
+if (
+	$a
+	&& $b
+	&& $c
+) {
+	echo 1;
+}
+
+// Mixed operators without parentheses — should be flagged (line 51).
+// phpcs:disable SlevomatCodingStandard.ControlStructures.RequireMultiLineCondition
+$d = $a && $b || $c;
+// phpcs:enable SlevomatCodingStandard.ControlStructures.RequireMultiLineCondition
+
+// Mixed operators with parentheses — should be allowed (line 55).
+// phpcs:disable SlevomatCodingStandard.ControlStructures.RequireMultiLineCondition
+$e = ( $a && $b ) || $c;
+// phpcs:enable SlevomatCodingStandard.ControlStructures.RequireMultiLineCondition

--- a/tests/Integration/Fixtures/BooleanOperators.inc
+++ b/tests/Integration/Fixtures/BooleanOperators.inc
@@ -27,7 +27,7 @@ if (
 	echo 1;
 }
 
-// Multi-line condition not fully split — should be flagged (line 31).
+// Multi-line condition not fully split — should be flagged (line 33).
 // phpcs:disable PSR12.ControlStructures.BooleanOperatorPlacement
 // phpcs:disable Generic.CodeAnalysis.RequireExplicitBooleanOperatorPrecedence
 if (
@@ -48,12 +48,12 @@ if (
 	echo 1;
 }
 
-// Mixed operators without parentheses — should be flagged (line 51).
+// Mixed operators without parentheses — should be flagged (line 53).
 // phpcs:disable SlevomatCodingStandard.ControlStructures.RequireMultiLineCondition
 $d = $a && $b || $c;
 // phpcs:enable SlevomatCodingStandard.ControlStructures.RequireMultiLineCondition
 
-// Mixed operators with parentheses — should be allowed (line 55).
+// Mixed operators with parentheses — should be allowed (line 58).
 // phpcs:disable SlevomatCodingStandard.ControlStructures.RequireMultiLineCondition
 $e = ( $a && $b ) || $c;
 // phpcs:enable SlevomatCodingStandard.ControlStructures.RequireMultiLineCondition

--- a/tests/Integration/Fixtures/ImplicitPostFunction.inc
+++ b/tests/Integration/Fixtures/ImplicitPostFunction.inc
@@ -1,0 +1,25 @@
+<?php
+// phpcs:disable WordPress,Squiz,PSR1,Apermo.WordPress.GlobalPostAccess,Generic,PSR2,PEAR,Universal
+// phpcs:disable SlevomatCodingStandard.TypeHints,SlevomatCodingStandard.Namespaces,SlevomatCodingStandard.PHP
+// phpcs:disable SlevomatCodingStandard.ControlStructures,SlevomatCodingStandard.Functions
+// phpcs:disable SlevomatCodingStandard.Variables,SlevomatCodingStandard.Classes
+
+// get_post_format without argument should be flagged (line 8).
+function test_get_post_format_missing() {
+	$format = get_post_format();
+}
+
+// get_post_format with explicit post should be allowed (line 13).
+function test_get_post_format_ok( $post ) {
+	$format = get_post_format( $post );
+}
+
+// the_post_thumbnail without argument should be flagged (line 18).
+function test_the_post_thumbnail_missing() {
+	the_post_thumbnail();
+}
+
+// the_post_thumbnail with size arg should still be flagged (line 23).
+function test_the_post_thumbnail_with_size() {
+	the_post_thumbnail( 'large' );
+}

--- a/tests/Integration/Fixtures/ImplicitPostFunction.inc
+++ b/tests/Integration/Fixtures/ImplicitPostFunction.inc
@@ -4,22 +4,22 @@
 // phpcs:disable SlevomatCodingStandard.ControlStructures,SlevomatCodingStandard.Functions
 // phpcs:disable SlevomatCodingStandard.Variables,SlevomatCodingStandard.Classes
 
-// get_post_format without argument should be flagged (line 8).
+// get_post_format without argument should be flagged (line 9).
 function test_get_post_format_missing() {
 	$format = get_post_format();
 }
 
-// get_post_format with explicit post should be allowed (line 13).
+// get_post_format with explicit post should be allowed (line 14).
 function test_get_post_format_ok( $post ) {
 	$format = get_post_format( $post );
 }
 
-// the_post_thumbnail without argument should be flagged (line 18).
+// the_post_thumbnail without argument should be flagged (line 19).
 function test_the_post_thumbnail_missing() {
 	the_post_thumbnail();
 }
 
-// the_post_thumbnail with size arg should still be flagged (line 23).
+// the_post_thumbnail with size arg should still be flagged (line 24).
 function test_the_post_thumbnail_with_size() {
 	the_post_thumbnail( 'large' );
 }

--- a/tests/Integration/Fixtures/VariableNameLength.inc
+++ b/tests/Integration/Fixtures/VariableNameLength.inc
@@ -11,3 +11,9 @@ $id = 42;
 $count = 5;
 // $ids should be allowed by default (line 12).
 $ids = [ 1, 2, 3 ];
+// $ip should be allowed by default (line 14).
+$ip = '127.0.0.1';
+// $ttl should be allowed by default (line 16).
+$ttl = 3600;
+// $uri should be allowed by default (line 18).
+$uri = '/path';

--- a/tests/Integration/RulesetIntegrationTest.php
+++ b/tests/Integration/RulesetIntegrationTest.php
@@ -444,4 +444,12 @@ class RulesetIntegrationTest extends TestCase {
 		$this->assertErrorOnLine( $file, 12, 'ClassStructure', 'Property after method should be flagged.' );
 		$this->assertNoErrorsOnLine( $file, 18, 'Correct class structure should be allowed.' );
 	}
+
+	public function testImplicitPostFunction(): void {
+		$file = $this->processFixture( 'ImplicitPostFunction.inc' );
+		$this->assertErrorOnLine( $file, 9, 'MissingArgument', 'get_post_format() without post should be flagged.' );
+		$this->assertNoErrorsOnLine( $file, 14, 'get_post_format() with post should be allowed.' );
+		$this->assertErrorOnLine( $file, 19, 'NoPostParameter', 'the_post_thumbnail() without argument should be flagged.' );
+		$this->assertErrorOnLine( $file, 24, 'NoPostParameter', 'the_post_thumbnail() with size should still be flagged.' );
+	}
 }

--- a/tests/Integration/RulesetIntegrationTest.php
+++ b/tests/Integration/RulesetIntegrationTest.php
@@ -452,4 +452,14 @@ class RulesetIntegrationTest extends TestCase {
 		$this->assertErrorOnLine( $file, 19, 'NoPostParameter', 'the_post_thumbnail() without argument should be flagged.' );
 		$this->assertErrorOnLine( $file, 24, 'NoPostParameter', 'the_post_thumbnail() with size should still be flagged.' );
 	}
+
+	public function testBooleanOperators(): void {
+		$file = $this->processFixture( 'BooleanOperators.inc' );
+		$this->assertErrorOnLine( $file, 15, 'BooleanOperatorPlacement', 'Operator at end of line should be flagged.' );
+		$this->assertNoErrorsOnLine( $file, 23, 'Operator at start of line should be allowed.' );
+		$this->assertErrorOnLine( $file, 33, 'RequireMultiLineCondition', 'Partially-split condition should be flagged.' );
+		$this->assertNoErrorsOnLine( $file, 43, 'Fully-split condition should be allowed.' );
+		$this->assertErrorOnLine( $file, 53, 'RequireExplicitBooleanOperatorPrecedence', 'Mixed operators without parens should be flagged.' );
+		$this->assertNoErrorsOnLine( $file, 58, 'Mixed operators with parens should be allowed.' );
+	}
 }

--- a/tests/Integration/RulesetIntegrationTest.php
+++ b/tests/Integration/RulesetIntegrationTest.php
@@ -245,6 +245,9 @@ class RulesetIntegrationTest extends TestCase {
 		$this->assertNoWarningsOnLine( $file, 9, 'Allowed short name should pass.' );
 		$this->assertNoWarningsOnLine( $file, 11, 'Long enough name should pass.' );
 		$this->assertNoWarningsOnLine( $file, 13, '$ids should be allowed by default.' );
+		$this->assertNoWarningsOnLine( $file, 15, '$ip should be allowed by default.' );
+		$this->assertNoWarningsOnLine( $file, 17, '$ttl should be allowed by default.' );
+		$this->assertNoWarningsOnLine( $file, 19, '$uri should be allowed by default.' );
 	}
 
 	public function testExitUsage(): void {


### PR DESCRIPTION
## Summary

- Add `ip`, `ttl`, `uri` to `MinimumVariableNameLength` default allowlist (Closes #92)
- Add `get_post_format` to `ImplicitPostFunction` sniff (Closes #87)
- Enforce boolean operator placement, multi-line splitting, and explicit precedence (Closes #86)

## Test plan

- [x] All 72 tests pass (193 assertions)
- [ ] CI checks pass