### PR TITLE
fix: resolve namespace rule conflicts

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -10,7 +10,7 @@ This is a `phpcodesniffer-standard` Composer package providing a shared PHPCS ru
 - Flag commented-out code.
 - Do not flag docblocks — these may be required by coding standards even when the function is self-explanatory.
 - Flag new code that duplicates existing functionality in the repository.
-- Every PHP file must start with `declare(strict_types=1);` after the opening `<?php` tag.
+- Every PHP file must start with `declare(strict_types=1);` after the opening `<?php` tag. Exception: PHPCS test fixtures (`tests/**/Fixtures/*.inc`) are intentionally minimal and omit it.
 - Prefer post-increment (`$var++`) over pre-increment (`++$var`).
 - In namespaced code, fully qualify PHP native functions (`\strlen()`, `\in_array()`) for performance. Do not fully qualify WordPress functions (`plugin_dir_path()`, `wp_remote_get()`) — it breaks mocking in unit tests.
 

--- a/Apermo/Sniffs/Commenting/DocCommentDescriptionSniff.php
+++ b/Apermo/Sniffs/Commenting/DocCommentDescriptionSniff.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Require a short description in doc comments, with exceptions.
+ *
+ * @package Apermo\Sniffs\Commenting
+ */
+
+namespace Apermo\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Replaces Generic.Commenting.DocComment.MissingShort with
+ * exceptions for `@see` and phpstan-ignore doc comments.
+ *
+ * A doc comment starting with `@see` is treated as a reference
+ * (e.g. pointing to where a WP hook is documented). A doc
+ * comment starting with a PHPStan ignore directive is a tool
+ * annotation, not a description.
+ */
+class DocCommentDescriptionSniff implements Sniff {
+
+	/**
+	 * Tags that satisfy the short description requirement.
+	 *
+	 * @var array<string>
+	 */
+	private const ALLOWED_TAGS = [
+		'@see',
+		'@phpstan-ignore',
+		'@phpstan-ignore-next-line',
+	];
+
+	/**
+	 * Returns an array of tokens this sniff listens for.
+	 *
+	 * @return array<int|string>
+	 */
+	public function register(): array {
+		return [ T_DOC_COMMENT_OPEN_TAG ];
+	}
+
+	/**
+	 * Processes a token.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ): void {
+		$tokens     = $phpcsFile->getTokens();
+		$commentEnd = $tokens[ $stackPtr ]['comment_closer'];
+
+		$empty = [
+			T_DOC_COMMENT_WHITESPACE,
+			T_DOC_COMMENT_STAR,
+		];
+
+		$short = $phpcsFile->findNext( $empty, ( $stackPtr + 1 ), $commentEnd, true );
+
+		if ( $short === false ) {
+			return;
+		}
+
+		if ( $tokens[ $short ]['code'] === T_DOC_COMMENT_STRING ) {
+			return;
+		}
+
+		if ( $tokens[ $short ]['code'] === T_DOC_COMMENT_TAG
+			&& \in_array( $tokens[ $short ]['content'], self::ALLOWED_TAGS, true )
+		) {
+			return;
+		}
+
+		$phpcsFile->addError(
+			'Missing short description in doc comment',
+			$stackPtr,
+			'MissingShort',
+		);
+	}
+}

--- a/Apermo/ruleset.xml
+++ b/Apermo/ruleset.xml
@@ -260,10 +260,12 @@
 	</rule>
 
 	<!-- Force explicit use imports instead of inline FQN references. -->
+	<!-- Skip no-namespace files: use statements are pointless there. -->
 	<rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
 		<properties>
 			<property name="allowFullyQualifiedGlobalConstants" value="true"/>
 			<property name="allowFullyQualifiedGlobalFunctions" value="true"/>
+			<property name="allowWhenNoNamespace" value="false"/>
 		</properties>
 	</rule>
 

--- a/Apermo/ruleset.xml
+++ b/Apermo/ruleset.xml
@@ -265,11 +265,11 @@
 	</rule>
 
 	<!-- Force explicit use imports instead of inline FQN references. -->
-	<!-- Skip no-namespace files: use statements are pointless there. -->
 	<rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
 		<properties>
 			<property name="allowFullyQualifiedGlobalConstants" value="true"/>
 			<property name="allowFullyQualifiedGlobalFunctions" value="true"/>
+			<!-- Counterintuitive: "false" means "do NOT enforce when no namespace"; "true" forces it. -->
 			<property name="allowWhenNoNamespace" value="false"/>
 		</properties>
 	</rule>

--- a/Apermo/ruleset.xml
+++ b/Apermo/ruleset.xml
@@ -13,6 +13,11 @@
 		<severity>0</severity>
 	</rule>
 
+	<!-- Superseded by Apermo.Commenting.DocCommentDescription. -->
+	<rule ref="Generic.Commenting.DocComment.MissingShort">
+		<severity>0</severity>
+	</rule>
+
 	<!-- WordPress Ruleset -->
 	<rule ref="WordPress">
 		<!-- We use short array syntax. -->

--- a/Apermo/ruleset.xml
+++ b/Apermo/ruleset.xml
@@ -281,9 +281,8 @@
 	<!-- Require backslash for global constants in namespaced code. -->
 	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants"/>
 
-	<!-- For namespaced functions/constants: import the namespace, not the function/constant. -->
+	<!-- For namespaced constants: import the namespace, not the constant. -->
 	<rule ref="Universal.UseStatements.DisallowUseConst"/>
-	<rule ref="Universal.UseStatements.DisallowUseFunction"/>
 
 	<rule ref="PSR1.Classes.ClassDeclaration"/>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] - Unreleased
+
+### Changed
+
+- Removed `Universal.UseStatements.DisallowUseFunction`.
+  `use function` imports are now allowed, resolving the
+  catch-22 where namespaced functions could neither be
+  imported nor called via FQN. Global function handling
+  is unaffected (`GlobalFunctionQualification` still
+  enforces backslash for native PHP functions).
+
+### Fixed
+
+- `SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly`
+  no longer fires in files without a namespace declaration.
+  FQN like `\Throwable` or `\RuntimeException` are valid
+  in no-namespace files where `use` statements are pointless.
+
 ## [2.6.4] - Unreleased
 
 ### Added
@@ -414,6 +432,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCompatibility checks targeting PHP 8.3+.
 - Empty `Apermo/Sniffs/` directory for future custom sniffs.
 
+[2.7.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.4...v2.7.0
 [2.6.4]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.3...v2.6.4
 [2.6.3]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.2...v2.6.3
 [2.6.2]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.1...v2.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.7.0] - Unreleased
 
+### Added
+
+- `Apermo.Commenting.DocCommentDescription` sniff: replaces
+  `Generic.Commenting.DocComment.MissingShort` with support
+  for `@see` and `@phpstan-ignore(-next-line)` as valid first
+  content in doc comments.
+- Project configuration guide in README with required
+  `phpcs.xml` properties (`text_domain`, `prefixes`,
+  `minimum_wp_version`) and a `phpcs.xml.dist.example` file.
+
 ### Changed
 
 - Removed `Universal.UseStatements.DisallowUseFunction`.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,64 @@ Then run:
 vendor/bin/phpcs
 ```
 
+## Project Configuration
+
+The Apermo standard includes rules that require project-specific settings. Without these, you either get false positives
+or miss valid warnings. Copy [`phpcs.xml.dist.example`](phpcs.xml.dist.example) as a starting point, or add the
+properties below to your existing `phpcs.xml`.
+
+### Text Domain (`text_domain`)
+
+`WordPress.WP.I18n` validates that all translation calls use the correct text domain. Set this to your plugin or
+theme slug:
+
+```xml
+<rule ref="WordPress.WP.I18n">
+    <properties>
+        <property name="text_domain" type="array">
+            <element value="my-plugin"/>
+        </property>
+    </properties>
+</rule>
+```
+
+### Global Prefixes (`prefixes`)
+
+`WordPress.NamingConventions.PrefixAllGlobals` checks that global functions, hooks, constants, and namespace
+declarations use your project prefix. Two entries are needed because the namespace root is PascalCase while the
+function/hook prefix is snake_case:
+
+```xml
+<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+    <properties>
+        <property name="prefixes" type="array">
+            <element value="My_Plugin"/>
+            <element value="my_plugin"/>
+        </property>
+    </properties>
+</rule>
+```
+
+The PascalCase entry allows `namespace My_Plugin\Admin;` but flags `namespace Other\Admin;`. The snake_case entry
+validates function names like `my_plugin_init()` and hook names like `my_plugin_loaded`.
+
+For nested namespace roots (e.g. a vendor namespace), set the full root:
+
+```xml
+<element value="Acme\My_Plugin"/>
+```
+
+This allows `namespace Acme\My_Plugin\Admin;` but flags `namespace Acme\Other;`.
+
+### Minimum WordPress Version (`minimum_wp_version`)
+
+Controls which WordPress functions are flagged as deprecated. Set this to the oldest WordPress version your project
+supports:
+
+```xml
+<config name="minimum_wp_version" value="6.2"/>
+```
+
 ## What's Included
 
 | Standard | Purpose |
@@ -241,17 +299,7 @@ $id = get_the_ID(); // allowed (in default allowlist)
 
 ### Text Domain Validation
 
-`WordPress.WP.I18n` text domain checking is active via the WordPress ruleset. Configure your project's text domain in your `phpcs.xml`:
-
-```xml
-<rule ref="WordPress.WP.I18n">
-    <properties>
-        <property name="text_domain" type="array">
-            <element value="my-plugin"/>
-        </property>
-    </properties>
-</rule>
-```
+`WordPress.WP.I18n` text domain checking is active via the WordPress ruleset. See [Project Configuration](#project-configuration) for setup instructions.
 
 ### Forbidden Nested Closures (`Apermo.Functions.ForbiddenNestedClosure`)
 

--- a/phpcs.xml.dist.example
+++ b/phpcs.xml.dist.example
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <description>PHPCS configuration for my-plugin.</description>
+
+    <file>.</file>
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>node_modules/*</exclude-pattern>
+
+    <rule ref="Apermo"/>
+
+    <!-- Project text domain for i18n validation. -->
+    <rule ref="WordPress.WP.I18n">
+        <properties>
+            <property name="text_domain" type="array">
+                <element value="my-plugin"/>
+            </property>
+        </properties>
+    </rule>
+
+    <!--
+        Project prefixes for global functions, hooks, constants, and namespace roots.
+        Two entries are needed because the namespace root is PascalCase while the
+        function/hook prefix is snake_case.
+    -->
+    <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+        <properties>
+            <property name="prefixes" type="array">
+                <element value="My_Plugin"/>
+                <element value="my_plugin"/>
+            </property>
+        </properties>
+    </rule>
+
+    <!-- Minimum supported WordPress version (controls deprecated function warnings). -->
+    <config name="minimum_wp_version" value="6.2"/>
+</ruleset>

--- a/tests/Integration/Fixtures/DocCommentDescription.inc
+++ b/tests/Integration/Fixtures/DocCommentDescription.inc
@@ -21,3 +21,7 @@ $param = 4;
 // Normal short description should pass (line 22).
 /** Short description. */
 $normal = 5;
+
+// Empty doc comment should not be flagged (line 26).
+/** */
+$empty = 6;

--- a/tests/Integration/Fixtures/DocCommentDescription.inc
+++ b/tests/Integration/Fixtures/DocCommentDescription.inc
@@ -1,0 +1,23 @@
+<?php
+// phpcs:disable WordPress,Squiz,PSR1,SlevomatCodingStandard,Generic,PSR2,PSR12,PEAR,Universal,Apermo
+// phpcs:enable Apermo.Commenting.DocCommentDescription
+
+// @see should satisfy the short description (line 6).
+/** @see wp-includes/post-template.php */
+$see = 1;
+
+// @phpstan-ignore-next-line should satisfy (line 10).
+/** @phpstan-ignore-next-line OB level can be 0. */
+$phpstan = 2;
+
+// @phpstan-ignore should satisfy (line 14).
+/** @phpstan-ignore argument.type */
+$phpstan2 = 3;
+
+// @param without short description should be flagged (line 18).
+/** @param string $foo */
+$param = 4;
+
+// Normal short description should pass (line 22).
+/** Short description. */
+$normal = 5;

--- a/tests/Integration/Fixtures/FqnInNoNamespace.inc
+++ b/tests/Integration/Fixtures/FqnInNoNamespace.inc
@@ -1,0 +1,12 @@
+<?php
+// phpcs:disable WordPress,Squiz,PSR1,SlevomatCodingStandard.TypeHints,SlevomatCodingStandard.Functions
+// phpcs:disable SlevomatCodingStandard.Variables,SlevomatCodingStandard.Classes,SlevomatCodingStandard.Complexity
+// phpcs:disable SlevomatCodingStandard.Arrays,SlevomatCodingStandard.Operators,SlevomatCodingStandard.PHP
+// phpcs:disable SlevomatCodingStandard.ControlStructures,Generic,PSR2,PSR12,PEAR,Universal,Apermo
+
+// No namespace — FQN should be allowed (line 8).
+try {
+	throw new \RuntimeException( 'test' );
+} catch ( \Throwable $error ) {
+	echo $error->getMessage();
+}

--- a/tests/Integration/Fixtures/UseFunctionAllowed.inc
+++ b/tests/Integration/Fixtures/UseFunctionAllowed.inc
@@ -1,0 +1,18 @@
+<?php
+// phpcs:disable WordPress,Squiz,PSR1,SlevomatCodingStandard.TypeHints,SlevomatCodingStandard.Functions
+// phpcs:disable SlevomatCodingStandard.Variables,SlevomatCodingStandard.Classes,SlevomatCodingStandard.Complexity
+// phpcs:disable SlevomatCodingStandard.Arrays,SlevomatCodingStandard.Operators,SlevomatCodingStandard.PHP
+// phpcs:disable SlevomatCodingStandard.ControlStructures,Generic,PSR2,PSR12,PEAR
+// phpcs:disable Universal.Operators,Universal.Arrays,Universal.ControlStructures
+// phpcs:disable Universal.FunctionDeclarations
+// phpcs:disable Apermo
+// phpcs:disable SlevomatCodingStandard.Namespaces.UnusedUses
+// phpcs:disable SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses
+
+namespace Apermo\Test;
+
+// use function should be allowed (line 15).
+use function Activitypub\get_webfinger_resource;
+
+// use const should still be disallowed (line 18).
+use const Activitypub\PLUGIN_VERSION;

--- a/tests/Integration/Fixtures/UseStatements.inc
+++ b/tests/Integration/Fixtures/UseStatements.inc
@@ -7,7 +7,7 @@ namespace Apermo\Tests\Integration\Fixtures;
 use RuntimeException;
 // use const — should be flagged (line 9).
 use const PHP_EOL;
-// use function — should be flagged (line 11).
+// use function — should be allowed (line 11).
 use function array_map;
 
 class UseStatementFixture {

--- a/tests/Integration/RulesetIntegrationTest.php
+++ b/tests/Integration/RulesetIntegrationTest.php
@@ -462,4 +462,10 @@ class RulesetIntegrationTest extends TestCase {
 		$this->assertErrorOnLine( $file, 53, 'RequireExplicitBooleanOperatorPrecedence', 'Mixed operators without parens should be flagged.' );
 		$this->assertNoErrorsOnLine( $file, 58, 'Mixed operators with parens should be allowed.' );
 	}
+
+	public function testFqnAllowedInNoNamespaceFiles(): void {
+		$file = $this->processFixture( 'FqnInNoNamespace.inc' );
+		$this->assertNoErrorsOnLine( $file, 9, 'FQN class in no-namespace file should be allowed.' );
+		$this->assertNoErrorsOnLine( $file, 10, 'FQN interface in no-namespace file should be allowed.' );
+	}
 }

--- a/tests/Integration/RulesetIntegrationTest.php
+++ b/tests/Integration/RulesetIntegrationTest.php
@@ -476,6 +476,7 @@ class RulesetIntegrationTest extends TestCase {
 		$this->assertNoErrorsOnLine( $file, 14, '@phpstan-ignore should satisfy.' );
 		$this->assertErrorOnLine( $file, 18, 'MissingShort', '@param without short desc should be flagged.' );
 		$this->assertNoErrorsOnLine( $file, 22, 'Normal short description should pass.' );
+		$this->assertNoErrorsOnLine( $file, 26, 'Empty doc comment should not be flagged.' );
 	}
 
 	public function testFqnAllowedInNoNamespaceFiles(): void {

--- a/tests/Integration/RulesetIntegrationTest.php
+++ b/tests/Integration/RulesetIntegrationTest.php
@@ -207,7 +207,7 @@ class RulesetIntegrationTest extends TestCase {
 		$file = $this->processFixture( 'UseStatements.inc' );
 		$this->assertErrorOnLine( $file, 7, 'UnusedUses', 'Unused use statement should be flagged.' );
 		$this->assertErrorOnLine( $file, 9, 'DisallowUseConst', 'use const should be flagged.' );
-		$this->assertErrorOnLine( $file, 11, 'DisallowUseFunction', 'use function should be flagged.' );
+		$this->assertNoErrorsOnLine( $file, 11, 'use function should be allowed.' );
 	}
 
 	public function testConcatAtStartOfLine(): void {
@@ -461,6 +461,12 @@ class RulesetIntegrationTest extends TestCase {
 		$this->assertNoErrorsOnLine( $file, 43, 'Fully-split condition should be allowed.' );
 		$this->assertErrorOnLine( $file, 53, 'RequireExplicitBooleanOperatorPrecedence', 'Mixed operators without parens should be flagged.' );
 		$this->assertNoErrorsOnLine( $file, 58, 'Mixed operators with parens should be allowed.' );
+	}
+
+	public function testUseFunctionAllowed(): void {
+		$file = $this->processFixture( 'UseFunctionAllowed.inc' );
+		$this->assertNoErrorsOnLine( $file, 15, 'use function should be allowed.' );
+		$this->assertErrorOnLine( $file, 18, 'DisallowUseConst', 'use const should still be disallowed.' );
 	}
 
 	public function testFqnAllowedInNoNamespaceFiles(): void {

--- a/tests/Integration/RulesetIntegrationTest.php
+++ b/tests/Integration/RulesetIntegrationTest.php
@@ -469,6 +469,15 @@ class RulesetIntegrationTest extends TestCase {
 		$this->assertErrorOnLine( $file, 18, 'DisallowUseConst', 'use const should still be disallowed.' );
 	}
 
+	public function testDocCommentDescription(): void {
+		$file = $this->processFixture( 'DocCommentDescription.inc' );
+		$this->assertNoErrorsOnLine( $file, 6, '@see should satisfy the short description.' );
+		$this->assertNoErrorsOnLine( $file, 10, '@phpstan-ignore-next-line should satisfy.' );
+		$this->assertNoErrorsOnLine( $file, 14, '@phpstan-ignore should satisfy.' );
+		$this->assertErrorOnLine( $file, 18, 'MissingShort', '@param without short desc should be flagged.' );
+		$this->assertNoErrorsOnLine( $file, 22, 'Normal short description should pass.' );
+	}
+
 	public function testFqnAllowedInNoNamespaceFiles(): void {
 		$file = $this->processFixture( 'FqnInNoNamespace.inc' );
 		$this->assertNoErrorsOnLine( $file, 9, 'FQN class in no-namespace file should be allowed.' );


### PR DESCRIPTION
## Summary

- Allow FQN in no-namespace files — skip `ReferenceUsedNamesOnly` where `use` statements are pointless (Closes #91)
- Allow `use function` imports — remove `DisallowUseFunction` to resolve the catch-22 with namespaced functions (Closes #81, Closes #85)

## Test plan

- [x] 74 tests pass (197 assertions)
- [x] CI checks pass