### PR TITLE
2.8.0: DocSummaryStyle + ArrayComplexity tuning + false-positive fixes

### DIFF
--- a/Apermo/Sniffs/Arrays/ConsistentDoubleArrowAlignmentSniff.php
+++ b/Apermo/Sniffs/Arrays/ConsistentDoubleArrowAlignmentSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Enforce consistent => alignment within arrays.
+ * Enforces consistent => alignment within arrays.
  *
  * @package Apermo\Sniffs\Arrays
  */
@@ -69,7 +69,7 @@ class ConsistentDoubleArrowAlignmentSniff implements Sniff {
 	}
 
 	/**
-	 * Collect top-level T_DOUBLE_ARROW tokens and their spacing info.
+	 * Collects top-level T_DOUBLE_ARROW tokens and their spacing info.
 	 *
 	 * Skips nested arrays, closures, and anonymous classes.
 	 *
@@ -129,7 +129,7 @@ class ConsistentDoubleArrowAlignmentSniff implements Sniff {
 	}
 
 	/**
-	 * Measure spaces between end of key and the => operator.
+	 * Measures spaces between end of key and the => operator.
 	 *
 	 * @param File $phpcsFile The file being scanned.
 	 * @param int  $arrowPtr  The T_DOUBLE_ARROW token position.
@@ -155,7 +155,7 @@ class ConsistentDoubleArrowAlignmentSniff implements Sniff {
 	}
 
 	/**
-	 * Check consistency within collected arrows and report violations.
+	 * Checks consistency within collected arrows and report violations.
 	 *
 	 * Two valid styles:
 	 * - Single-space: all `=>` have exactly 1 space before them

--- a/Apermo/Sniffs/CodeQuality/ExcessiveParameterCountSniff.php
+++ b/Apermo/Sniffs/CodeQuality/ExcessiveParameterCountSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Flag functions with too many parameters.
+ * Flags functions with too many parameters.
  *
  * @package Apermo\Sniffs\CodeQuality
  */

--- a/Apermo/Sniffs/Commenting/DocCommentDescriptionSniff.php
+++ b/Apermo/Sniffs/Commenting/DocCommentDescriptionSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Require a short description in doc comments, with exceptions.
+ * Requires a short description in doc comments, with exceptions.
  *
  * @package Apermo\Sniffs\Commenting
  */

--- a/Apermo/Sniffs/Commenting/DocSummaryStyleSniff.php
+++ b/Apermo/Sniffs/Commenting/DocSummaryStyleSniff.php
@@ -1,0 +1,193 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Enforces WordPress docblock summary style.
+ *
+ * @package Apermo\Sniffs\Commenting
+ */
+
+namespace Apermo\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Enforces third-person singular style for docblock summaries.
+ *
+ * Per the WordPress PHP Documentation Standards, summaries for functions,
+ * hooks, classes, and methods must be written in the third-person singular —
+ * prepending "It" to the summary should read grammatically. Applies a layered
+ * check: whitelist → anti-patterns → bare-infinitive closers → default
+ * (first word ends in "s").
+ *
+ * Error codes:
+ * - AntiPattern: leading phrase matches a known bad opener (e.g. "Allows you to...").
+ * - BareInfinitive: first word is a bare-infinitive verb whose third-person form adds -es.
+ * - NotThirdPerson: first word does not end in "s".
+ */
+class DocSummaryStyleSniff implements Sniff {
+
+	/**
+	 * First words that bypass the summary-style check.
+	 *
+	 * Common noun-lead openings that WordPress style tolerates.
+	 *
+	 * @var array<string>
+	 */
+	public array $whitelist = [
+		'Callback',
+		'Wrapper',
+		'Helper',
+		'Utility',
+		'Alias',
+		'Shortcut',
+	];
+
+	/**
+	 * Leading phrases that flag a summary as using a known anti-pattern.
+	 *
+	 * Matched as a case-insensitive prefix of the cleaned summary.
+	 *
+	 * @var array<string>
+	 */
+	public array $antiPatterns = [
+		'Allows you to',
+		'Lets you',
+		'Allow you to',
+		'Let you',
+		'Used to',
+		'This function',
+		'This method',
+		'This class',
+	];
+
+	/**
+	 * Bare-infinitive verbs whose third-person singular form adds -es.
+	 *
+	 * These slip past the default "ends in s" check because the bare
+	 * infinitive itself already ends in s/ss/x.
+	 *
+	 * @var array<string>
+	 */
+	public array $bareInfinitiveClosers = [
+		'Process',
+		'Pass',
+		'Access',
+		'Focus',
+		'Fix',
+		'Mix',
+		'Cross',
+		'Miss',
+		'Dismiss',
+		'Address',
+		'Express',
+		'Bypass',
+		'Discuss',
+	];
+
+	/**
+	 * Returns the tokens this sniff listens for.
+	 *
+	 * @return array<int|string>
+	 */
+	public function register(): array {
+		return [ T_DOC_COMMENT_OPEN_TAG ];
+	}
+
+	/**
+	 * Processes a token.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ): void {
+		$tokens     = $phpcsFile->getTokens();
+		$commentEnd = $tokens[ $stackPtr ]['comment_closer'];
+		$empty      = [ T_DOC_COMMENT_WHITESPACE, T_DOC_COMMENT_STAR ];
+
+		$first = $phpcsFile->findNext( $empty, ( $stackPtr + 1 ), $commentEnd, true );
+
+		if ( $first === false ) {
+			return;
+		}
+
+		// Not a free-text summary (e.g. docblock starts with a tag like @param).
+		if ( $tokens[ $first ]['code'] !== T_DOC_COMMENT_STRING ) {
+			return;
+		}
+
+		$summary = $tokens[ $first ]['content'];
+
+		// {@inheritDoc} / @inheritdoc variants — not a summary.
+		if ( preg_match( '/^\s*\{?@?inheritdoc\}?\s*$/i', $summary ) === 1 ) {
+			return;
+		}
+
+		$cleaned = $this->cleanSummary( $summary );
+		if ( $cleaned === '' ) {
+			return;
+		}
+
+		if ( preg_match( '/^([A-Za-z][A-Za-z\']*)/', $cleaned, $m ) !== 1 ) {
+			return;
+		}
+		$firstWord = $m[1];
+
+		foreach ( $this->whitelist as $allowed ) {
+			if ( strcasecmp( $firstWord, $allowed ) === 0 ) {
+				return;
+			}
+		}
+
+		foreach ( $this->antiPatterns as $bad ) {
+			if ( stripos( $cleaned, $bad ) === 0 ) {
+				$phpcsFile->addWarning(
+					'Docblock summary starts with "%s" — rewrite as what the element does (third-person singular per WordPress docs)',
+					$first,
+					'AntiPattern',
+					[ $bad ],
+				);
+				return;
+			}
+		}
+
+		foreach ( $this->bareInfinitiveClosers as $verb ) {
+			if ( strcasecmp( $firstWord, $verb ) === 0 ) {
+				$phpcsFile->addWarning(
+					'Docblock summary first word "%s" is a bare infinitive — use the third-person singular form (e.g. Processes, Passes, Fixes)',
+					$first,
+					'BareInfinitive',
+					[ $firstWord ],
+				);
+				return;
+			}
+		}
+
+		if ( substr( strtolower( $firstWord ), -1 ) !== 's' ) {
+			$phpcsFile->addWarning(
+				'Docblock summary first word "%s" does not end in "s" — use third-person singular per WordPress docs (mental test: prepending "It" must read grammatically)',
+				$first,
+				'NotThirdPerson',
+				[ $firstWord ],
+			);
+		}
+	}
+
+	/**
+	 * Strips a leading backtick-quoted code reference and leading punctuation.
+	 *
+	 * @param string $summary Raw summary content.
+	 *
+	 * @return string Cleaned summary.
+	 */
+	private function cleanSummary( string $summary ): string {
+		$cleaned = preg_replace( '/^`[^`]*`\s*/', '', $summary );
+		if ( $cleaned === null ) {
+			$cleaned = $summary;
+		}
+		return ltrim( $cleaned, " \t\"'*([{" );
+	}
+}

--- a/Apermo/Sniffs/Commenting/DocSummaryStyleSniff.php
+++ b/Apermo/Sniffs/Commenting/DocSummaryStyleSniff.php
@@ -108,6 +108,13 @@ class DocSummaryStyleSniff implements Sniff {
 		$commentEnd = $tokens[ $stackPtr ]['comment_closer'];
 		$empty      = [ T_DOC_COMMENT_WHITESPACE, T_DOC_COMMENT_STAR ];
 
+		// Properties, constants, and bare variables use noun-form summaries;
+		// the third-person rule only applies to behavior-describing docblocks
+		// (functions, methods, classes, interfaces, traits, enums).
+		if ( $this->describesDataDeclaration( $phpcsFile, $commentEnd ) ) {
+			return;
+		}
+
 		$first = $phpcsFile->findNext( $empty, ( $stackPtr + 1 ), $commentEnd, true );
 
 		if ( $first === false ) {
@@ -174,6 +181,47 @@ class DocSummaryStyleSniff implements Sniff {
 				[ $firstWord ],
 			);
 		}
+	}
+
+	/**
+	 * Reports whether the docblock attaches to a property, constant, or bare variable.
+	 *
+	 * Scans forward from the docblock's closing tag and returns true if the
+	 * first attachable declaration encountered is a property / constant /
+	 * variable (noun-form summaries are idiomatic), false if it is a function,
+	 * class, interface, trait, or enum (third-person rule applies).
+	 *
+	 * @param File $phpcsFile    The file being scanned.
+	 * @param int  $commentClose Position of the docblock's T_DOC_COMMENT_CLOSE_TAG.
+	 *
+	 * @return bool
+	 */
+	private function describesDataDeclaration( File $phpcsFile, int $commentClose ): bool {
+		$tokens = $phpcsFile->getTokens();
+		$end    = $phpcsFile->numTokens;
+
+		for ( $i = $commentClose + 1; $i < $end; $i++ ) {
+			$code = $tokens[ $i ]['code'];
+
+			if ( $code === T_FUNCTION
+				|| $code === T_CLASS
+				|| $code === T_INTERFACE
+				|| $code === T_TRAIT
+				|| ( defined( 'T_ENUM' ) && $code === T_ENUM )
+			) {
+				return false;
+			}
+
+			if ( $code === T_VARIABLE || $code === T_CONST ) {
+				return true;
+			}
+
+			if ( $code === T_DOC_COMMENT_OPEN_TAG ) {
+				return false;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/Apermo/Sniffs/Commenting/DocSummaryStyleSniff.php
+++ b/Apermo/Sniffs/Commenting/DocSummaryStyleSniff.php
@@ -232,10 +232,7 @@ class DocSummaryStyleSniff implements Sniff {
 	 * @return string Cleaned summary.
 	 */
 	private function cleanSummary( string $summary ): string {
-		$cleaned = preg_replace( '/^`[^`]*`\s*/', '', $summary );
-		if ( $cleaned === null ) {
-			$cleaned = $summary;
-		}
+		$cleaned = preg_replace( '/^`[^`]*`\s*/', '', $summary ) ?? $summary;
 		return ltrim( $cleaned, " \t\"'*([{" );
 	}
 }

--- a/Apermo/Sniffs/DataStructures/ArrayComplexitySniff.php
+++ b/Apermo/Sniffs/DataStructures/ArrayComplexitySniff.php
@@ -96,7 +96,7 @@ class ArrayComplexitySniff implements Sniff {
 	 * @return array<int|string>
 	 */
 	public function register() {
-		return [ T_OPEN_SHORT_ARRAY, T_ARRAY, T_FUNCTION, T_CLOSURE ];
+		return [ T_OPEN_SHORT_ARRAY, T_ARRAY, T_FUNCTION, T_CLOSURE, T_FN ];
 	}
 
 	/**
@@ -118,7 +118,7 @@ class ArrayComplexitySniff implements Sniff {
 		$tokens = $phpcsFile->getTokens();
 		$code   = $tokens[ $stackPtr ]['code'];
 
-		if ( $code === T_FUNCTION || $code === T_CLOSURE ) {
+		if ( $code === T_FUNCTION || $code === T_CLOSURE || $code === T_FN ) {
 			$this->processFunctionSignature( $phpcsFile, $stackPtr );
 			return;
 		}
@@ -230,7 +230,7 @@ class ArrayComplexitySniff implements Sniff {
 				if ( ! $depthIsAssoc[ $depth ] ) {
 					$depthIsAssoc[ $depth ] = true;
 					$assocCount++;
-					$maxAssocCount = max( $maxAssocCount, $assocCount );
+					$maxAssocCount = \max( $maxAssocCount, $assocCount );
 				}
 			}
 		}
@@ -452,7 +452,7 @@ class ArrayComplexitySniff implements Sniff {
 			}
 		}
 
-		return trim( implode( ' ', $parts ) );
+		return \trim( \implode( ' ', $parts ) );
 	}
 
 	/**
@@ -462,13 +462,13 @@ class ArrayComplexitySniff implements Sniff {
 	 * or null if no shape is present or the braces are unbalanced.
 	 */
 	private function extractArrayShapeBody( string $content ): ?string {
-		if ( preg_match( '/\b(?:array|list)\s*\{/', $content, $match, PREG_OFFSET_CAPTURE ) !== 1 ) {
+		if ( \preg_match( '/\b(?:array|list)\s*\{/', $content, $match, PREG_OFFSET_CAPTURE ) !== 1 ) {
 			return null;
 		}
 
-		$start = $match[0][1] + strlen( $match[0][0] );
+		$start = $match[0][1] + \strlen( $match[0][0] );
 		$depth = 1;
-		$len   = strlen( $content );
+		$len   = \strlen( $content );
 
 		for ( $i = $start; $i < $len; $i++ ) {
 			if ( $content[ $i ] === '{' ) {
@@ -476,7 +476,7 @@ class ArrayComplexitySniff implements Sniff {
 			} elseif ( $content[ $i ] === '}' ) {
 				$depth--;
 				if ( $depth === 0 ) {
-					return substr( $content, $start, $i - $start );
+					return \substr( $content, $start, $i - $start );
 				}
 			}
 		}
@@ -485,10 +485,18 @@ class ArrayComplexitySniff implements Sniff {
 	}
 
 	/**
-	 * Extracts the first `$name` token from $content.
+	 * Extracts the parameter name from an @param tag's content.
+	 *
+	 * Searches after the last closing brace of the array shape (if any) so
+	 * variables that appear inside the type definition itself — e.g.
+	 * `@param array{foo: $this} $opts` — are not confused with the real
+	 * parameter name.
 	 */
 	private function extractParamName( string $content ): string {
-		if ( preg_match( '/\$(\w+)/', $content, $match ) === 1 ) {
+		$lastBrace = \strrpos( $content, '}' );
+		$searchIn  = ( $lastBrace !== false ) ? \substr( $content, $lastBrace ) : $content;
+
+		if ( \preg_match( '/\$(\w+)/', $searchIn, $match ) === 1 ) {
 			return '$' . $match[1];
 		}
 
@@ -498,18 +506,22 @@ class ArrayComplexitySniff implements Sniff {
 	/**
 	 * Counts top-level entries and max nesting depth of an array-shape body.
 	 *
-	 * Walks $body character by character, tracking brace depth. Commas at
-	 * depth 0 separate top-level entries. Nested `{...}` blocks are
-	 * analyzed recursively and contribute to the reported depth.
+	 * Walks $body character by character, tracking brace, parenthesis, and
+	 * angle-bracket depth. Commas at depth 0 separate top-level entries.
+	 * Nested `{...}` blocks are analyzed recursively and contribute to the
+	 * reported depth. Commas inside `(...)` (callable signatures) and
+	 * `<...>` (generics) do not count as entry separators.
 	 *
 	 * @return array{depth: int, keys: int}
 	 */
 	private function analyzeShapeBody( string $body ): array {
-		$len         = strlen( $body );
+		$len         = \strlen( $body );
 		$keys        = 0;
 		$hasContent  = false;
 		$nestedMax   = 0;
 		$braceDepth  = 0;
+		$parenDepth  = 0;
+		$angleDepth  = 0;
 		$nestedStart = null;
 
 		for ( $i = 0; $i < $len; $i++ ) {
@@ -526,14 +538,34 @@ class ArrayComplexitySniff implements Sniff {
 			if ( $ch === '}' ) {
 				$braceDepth--;
 				if ( $braceDepth === 0 && $nestedStart !== null ) {
-					$nested      = $this->analyzeShapeBody( substr( $body, $nestedStart, $i - $nestedStart ) );
-					$nestedMax   = max( $nestedMax, $nested['depth'] );
+					$nested      = $this->analyzeShapeBody( \substr( $body, $nestedStart, $i - $nestedStart ) );
+					$nestedMax   = \max( $nestedMax, $nested['depth'] );
 					$nestedStart = null;
 				}
 				continue;
 			}
 
-			if ( $braceDepth > 0 ) {
+			if ( $ch === '(' ) {
+				$parenDepth++;
+				continue;
+			}
+
+			if ( $ch === ')' ) {
+				$parenDepth--;
+				continue;
+			}
+
+			if ( $ch === '<' ) {
+				$angleDepth++;
+				continue;
+			}
+
+			if ( $ch === '>' ) {
+				$angleDepth--;
+				continue;
+			}
+
+			if ( $braceDepth > 0 || $parenDepth > 0 || $angleDepth > 0 ) {
 				continue;
 			}
 
@@ -545,7 +577,7 @@ class ArrayComplexitySniff implements Sniff {
 				continue;
 			}
 
-			if ( ! ctype_space( $ch ) ) {
+			if ( ! \ctype_space( $ch ) ) {
 				$hasContent = true;
 			}
 		}

--- a/Apermo/Sniffs/DataStructures/ArrayComplexitySniff.php
+++ b/Apermo/Sniffs/DataStructures/ArrayComplexitySniff.php
@@ -11,17 +11,25 @@ namespace Apermo\Sniffs\DataStructures;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Flags deeply nested or wide associative arrays that would benefit
  * from being typed objects (DTOs, value objects).
  *
- * Two independent checks fire per array:
- * - Nesting depth: counts levels of associative array nesting.
- * - Key count: counts top-level associative keys.
+ * Three independent checks fire:
+ * - Literal nesting depth: counts associative nesting levels in an
+ *   outermost array literal (warning / error).
+ * - Literal key count: counts top-level associative keys in an
+ *   outermost array literal (warning / error).
+ * - Parameter shape complexity: flags custom function/method/closure
+ *   parameters whose default value or `@param array{...}` docblock
+ *   shape exceeds `parameterMaxKeys` or `parameterMaxDepth` (error).
  *
- * Only outermost arrays are checked (inner arrays are skipped via
- * the return value from process()).
+ * For literals, the outermost-array-only limit means the canonical
+ * fix for a `TooDeep` warning is to extract the complex sub-array
+ * into its own variable, which splits one deep literal into two
+ * shallower ones.
  */
 class ArrayComplexitySniff implements Sniff {
 
@@ -61,29 +69,61 @@ class ArrayComplexitySniff implements Sniff {
 	public int $errorKeys = 20;
 
 	/**
+	 * Max associative nesting depth allowed in a parameter array shape.
+	 *
+	 * Stricter than the literal thresholds: the function author owns the
+	 * signature and can refactor to a DTO. Exceeding this triggers an
+	 * error on `ComplexParameterDepth`.
+	 *
+	 * @var int
+	 */
+	public int $parameterMaxDepth = 2;
+
+	/**
+	 * Max top-level keys allowed in a parameter array shape.
+	 *
+	 * Stricter than the literal thresholds: the function author owns the
+	 * signature and can refactor to a DTO. Exceeding this triggers an
+	 * error on `ComplexParameterKeys`.
+	 *
+	 * @var int
+	 */
+	public int $parameterMaxKeys = 5;
+
+	/**
 	 * Returns an array of tokens this sniff listens for.
 	 *
 	 * @return array<int|string>
 	 */
 	public function register() {
-		return [ T_OPEN_SHORT_ARRAY, T_ARRAY ];
+		return [ T_OPEN_SHORT_ARRAY, T_ARRAY, T_FUNCTION, T_CLOSURE ];
 	}
 
 	/**
 	 * Processes a token.
 	 *
-	 * Returns the position after the array closer so that PHPCS skips
-	 * all nested arrays — only outermost arrays are analyzed.
+	 * For array tokens, returns the position after the array closer so
+	 * PHPCS skips nested arrays — only outermost arrays are analyzed.
+	 *
+	 * For function/closure tokens, inspects parameter default values and
+	 * `@param array{...}` docblock shapes and reports parameter-signature
+	 * complexity errors. No skip — the function body is still walked.
 	 *
 	 * @param File $phpcsFile The file being scanned.
 	 * @param int  $stackPtr  The position of the current token.
 	 *
-	 * @return int Next position to process.
+	 * @return int|void Next position to process, or void to continue normally.
 	 */
 	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
+		$code   = $tokens[ $stackPtr ]['code'];
 
-		if ( $tokens[ $stackPtr ]['code'] === T_OPEN_SHORT_ARRAY ) {
+		if ( $code === T_FUNCTION || $code === T_CLOSURE ) {
+			$this->processFunctionSignature( $phpcsFile, $stackPtr );
+			return;
+		}
+
+		if ( $code === T_OPEN_SHORT_ARRAY ) {
 			$opener = $stackPtr;
 			$closer = $tokens[ $stackPtr ]['bracket_closer'] ?? null;
 		} else {
@@ -249,5 +289,274 @@ class ArrayComplexitySniff implements Sniff {
 				[ $topLevelKeys, $this->warnKeys ]
 			);
 		}
+	}
+
+	/**
+	 * Inspect a function/method/closure signature for complex parameter shapes.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  Position of the T_FUNCTION / T_CLOSURE token.
+	 */
+	private function processFunctionSignature( File $phpcsFile, int $stackPtr ): void {
+		$this->checkParameterDefaults( $phpcsFile, $stackPtr );
+		$this->checkParameterDocBlockShapes( $phpcsFile, $stackPtr );
+	}
+
+	/**
+	 * Flag parameters whose default value is a complex array literal.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  Position of the T_FUNCTION / T_CLOSURE token.
+	 */
+	private function checkParameterDefaults( File $phpcsFile, int $stackPtr ): void {
+		$tokens = $phpcsFile->getTokens();
+
+		try {
+			$params = $phpcsFile->getMethodParameters( $stackPtr );
+		} catch ( \Exception $e ) {
+			return;
+		}
+
+		foreach ( $params as $param ) {
+			if ( ! isset( $param['default_token'] ) ) {
+				continue;
+			}
+
+			$defaultPtr  = $param['default_token'];
+			$defaultCode = $tokens[ $defaultPtr ]['code'] ?? null;
+
+			if ( $defaultCode === T_OPEN_SHORT_ARRAY ) {
+				$opener = $defaultPtr;
+				$closer = $tokens[ $defaultPtr ]['bracket_closer'] ?? null;
+			} elseif ( $defaultCode === T_ARRAY ) {
+				$opener = $tokens[ $defaultPtr ]['parenthesis_opener'] ?? null;
+				$closer = $tokens[ $defaultPtr ]['parenthesis_closer'] ?? null;
+			} else {
+				continue;
+			}
+
+			if ( $opener === null || $closer === null ) {
+				continue;
+			}
+
+			$result = $this->countArrayComplexity( $tokens, $opener, $closer );
+			$this->reportParameterComplexity( $phpcsFile, $opener, $param['name'], $result );
+		}
+	}
+
+	/**
+	 * Flag parameters whose `@param array{...}` docblock shape is complex.
+	 *
+	 * Parses PHPStan/Psalm shape syntax — splits top-level entries by
+	 * comma (respecting nested braces) for the key count, and recurses
+	 * into nested `array{...}` entries for the depth.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  Position of the T_FUNCTION / T_CLOSURE token.
+	 */
+	private function checkParameterDocBlockShapes( File $phpcsFile, int $stackPtr ): void {
+		$tokens = $phpcsFile->getTokens();
+
+		$skip   = Tokens::$methodPrefixes;
+		$skip[] = T_WHITESPACE;
+
+		$commentEnd = $phpcsFile->findPrevious( $skip, $stackPtr - 1, null, true );
+		if ( $commentEnd === false
+			|| ! isset( $tokens[ $commentEnd ]['code'] )
+			|| $tokens[ $commentEnd ]['code'] !== T_DOC_COMMENT_CLOSE_TAG
+		) {
+			return;
+		}
+
+		$commentStart = $tokens[ $commentEnd ]['comment_opener'] ?? null;
+		if ( $commentStart === null ) {
+			return;
+		}
+
+		for ( $i = $commentStart; $i <= $commentEnd; $i++ ) {
+			if ( $tokens[ $i ]['code'] !== T_DOC_COMMENT_TAG ) {
+				continue;
+			}
+			if ( $tokens[ $i ]['content'] !== '@param' ) {
+				continue;
+			}
+
+			$content = $this->extractTagContent( $tokens, $i, $commentEnd );
+			if ( $content === '' ) {
+				continue;
+			}
+
+			$shapeBody = $this->extractArrayShapeBody( $content );
+			if ( $shapeBody === null ) {
+				continue;
+			}
+
+			$paramName = $this->extractParamName( $content );
+			if ( $paramName === '' ) {
+				$paramName = '(unnamed)';
+			}
+
+			$result = $this->analyzeShapeBody( $shapeBody );
+			$this->reportParameterComplexity( $phpcsFile, $i, $paramName, $result );
+		}
+	}
+
+	/**
+	 * Report parameter-shape violations.
+	 *
+	 * @param File                          $phpcsFile The file being scanned.
+	 * @param int                           $reportAt  Token position to attach the message to.
+	 * @param string                        $paramName The parameter name (for the message).
+	 * @param array{depth: int, keys: int}  $result    Complexity measurements.
+	 */
+	private function reportParameterComplexity( File $phpcsFile, int $reportAt, string $paramName, array $result ): void {
+		if ( $result['keys'] > $this->parameterMaxKeys ) {
+			$phpcsFile->addError(
+				'Parameter %s declares an array shape with %s keys; consider a typed object (max: %s)',
+				$reportAt,
+				'ComplexParameterKeys',
+				[ $paramName, $result['keys'], $this->parameterMaxKeys ]
+			);
+		}
+
+		if ( $result['depth'] > $this->parameterMaxDepth ) {
+			$phpcsFile->addError(
+				'Parameter %s declares a shape nested %s levels deep; consider a typed object (max: %s)',
+				$reportAt,
+				'ComplexParameterDepth',
+				[ $paramName, $result['depth'], $this->parameterMaxDepth ]
+			);
+		}
+	}
+
+	/**
+	 * Concatenate all T_DOC_COMMENT_STRING tokens belonging to a single tag.
+	 *
+	 * Multi-line tag values (e.g. a shape split across lines) are joined
+	 * with spaces, so `extractArrayShapeBody()` can operate on a single
+	 * string regardless of source layout.
+	 *
+	 * @param array<int, array<mixed>> $tokens     Token stack.
+	 * @param int                      $tagPtr     Position of the T_DOC_COMMENT_TAG.
+	 * @param int                      $commentEnd Position of the T_DOC_COMMENT_CLOSE_TAG.
+	 */
+	private function extractTagContent( array $tokens, int $tagPtr, int $commentEnd ): string {
+		$parts = [];
+		for ( $i = $tagPtr + 1; $i <= $commentEnd; $i++ ) {
+			$code = $tokens[ $i ]['code'];
+			if ( $code === T_DOC_COMMENT_TAG || $code === T_DOC_COMMENT_CLOSE_TAG ) {
+				break;
+			}
+			if ( $code === T_DOC_COMMENT_STRING ) {
+				$parts[] = $tokens[ $i ]['content'];
+			}
+		}
+
+		return trim( implode( ' ', $parts ) );
+	}
+
+	/**
+	 * Extract the body of the first `array{...}` or `list{...}` shape in $content.
+	 *
+	 * Returns the content between the outer `{` and its matching `}`,
+	 * or null if no shape is present or the braces are unbalanced.
+	 */
+	private function extractArrayShapeBody( string $content ): ?string {
+		if ( preg_match( '/\b(?:array|list)\s*\{/', $content, $match, PREG_OFFSET_CAPTURE ) !== 1 ) {
+			return null;
+		}
+
+		$start = $match[0][1] + strlen( $match[0][0] );
+		$depth = 1;
+		$len   = strlen( $content );
+
+		for ( $i = $start; $i < $len; $i++ ) {
+			if ( $content[ $i ] === '{' ) {
+				$depth++;
+			} elseif ( $content[ $i ] === '}' ) {
+				$depth--;
+				if ( $depth === 0 ) {
+					return substr( $content, $start, $i - $start );
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Extract the first `$name` token from $content.
+	 */
+	private function extractParamName( string $content ): string {
+		if ( preg_match( '/\$(\w+)/', $content, $match ) === 1 ) {
+			return '$' . $match[1];
+		}
+
+		return '';
+	}
+
+	/**
+	 * Count top-level entries and max nesting depth of an array-shape body.
+	 *
+	 * Walks $body character by character, tracking brace depth. Commas at
+	 * depth 0 separate top-level entries. Nested `{...}` blocks are
+	 * analyzed recursively and contribute to the reported depth.
+	 *
+	 * @return array{depth: int, keys: int}
+	 */
+	private function analyzeShapeBody( string $body ): array {
+		$len         = strlen( $body );
+		$keys        = 0;
+		$hasContent  = false;
+		$nestedMax   = 0;
+		$braceDepth  = 0;
+		$nestedStart = null;
+
+		for ( $i = 0; $i < $len; $i++ ) {
+			$ch = $body[ $i ];
+
+			if ( $ch === '{' ) {
+				if ( $braceDepth === 0 ) {
+					$nestedStart = $i + 1;
+				}
+				$braceDepth++;
+				continue;
+			}
+
+			if ( $ch === '}' ) {
+				$braceDepth--;
+				if ( $braceDepth === 0 && $nestedStart !== null ) {
+					$nested      = $this->analyzeShapeBody( substr( $body, $nestedStart, $i - $nestedStart ) );
+					$nestedMax   = max( $nestedMax, $nested['depth'] );
+					$nestedStart = null;
+				}
+				continue;
+			}
+
+			if ( $braceDepth > 0 ) {
+				continue;
+			}
+
+			if ( $ch === ',' ) {
+				if ( $hasContent ) {
+					$keys++;
+					$hasContent = false;
+				}
+				continue;
+			}
+
+			if ( ! ctype_space( $ch ) ) {
+				$hasContent = true;
+			}
+		}
+
+		if ( $hasContent ) {
+			$keys++;
+		}
+
+		return [
+			'depth' => 1 + $nestedMax,
+			'keys'  => $keys,
+		];
 	}
 }

--- a/Apermo/Sniffs/DataStructures/ArrayComplexitySniff.php
+++ b/Apermo/Sniffs/DataStructures/ArrayComplexitySniff.php
@@ -28,30 +28,37 @@ class ArrayComplexitySniff implements Sniff {
 	/**
 	 * Associative nesting depth that triggers a warning.
 	 *
+	 * Depth 3 is the shape of a `WP_Query` call with a `meta_query` — idiomatic
+	 * WordPress usage. The default stays silent on that pattern; deeper
+	 * nesting is the author's own design and warrants a nudge.
+	 *
 	 * @var int
 	 */
-	public int $warnDepth = 2;
+	public int $warnDepth = 3;
 
 	/**
 	 * Associative nesting depth that triggers an error.
 	 *
 	 * @var int
 	 */
-	public int $errorDepth = 3;
+	public int $errorDepth = 5;
 
 	/**
 	 * Number of top-level keys that triggers a warning.
 	 *
+	 * Typical `WP_Query` arg sets land in the 5–8 range; 10 keeps normal
+	 * WordPress API calls silent while flagging larger ad-hoc arrays.
+	 *
 	 * @var int
 	 */
-	public int $warnKeys = 5;
+	public int $warnKeys = 10;
 
 	/**
 	 * Number of top-level keys that triggers an error.
 	 *
 	 * @var int
 	 */
-	public int $errorKeys = 10;
+	public int $errorKeys = 20;
 
 	/**
 	 * Returns an array of tokens this sniff listens for.

--- a/Apermo/Sniffs/DataStructures/ArrayComplexitySniff.php
+++ b/Apermo/Sniffs/DataStructures/ArrayComplexitySniff.php
@@ -97,9 +97,6 @@ class ArrayComplexitySniff implements Sniff {
 	/**
 	 * Analyze an array for associative nesting depth and key count.
 	 *
-	 * Walks tokens between opener and closer in a single pass, tracking
-	 * depth and whether each level is associative (contains T_DOUBLE_ARROW).
-	 *
 	 * @param File                    $phpcsFile The file being scanned.
 	 * @param int                     $stackPtr  The position of the array token (for reporting).
 	 * @param array<int, array<mixed>> $tokens    Token stack.
@@ -107,6 +104,23 @@ class ArrayComplexitySniff implements Sniff {
 	 * @param int                     $closer    Position of the array closer.
 	 */
 	private function analyze( File $phpcsFile, int $stackPtr, array $tokens, int $opener, int $closer ): void {
+		$result = $this->countArrayComplexity( $tokens, $opener, $closer );
+
+		$this->checkDepth( $phpcsFile, $stackPtr, $result['depth'] );
+		$this->checkKeys( $phpcsFile, $stackPtr, $result['keys'] );
+	}
+
+	/**
+	 * Walks tokens between an array opener and closer in a single pass,
+	 * tracking associative nesting depth and top-level key count.
+	 *
+	 * @param array<int, array<mixed>> $tokens Token stack.
+	 * @param int                      $opener Position of the array opener.
+	 * @param int                      $closer Position of the array closer.
+	 *
+	 * @return array{depth: int, keys: int}
+	 */
+	private function countArrayComplexity( array $tokens, int $opener, int $closer ): array {
 		$depth         = 1;
 		$depthIsAssoc  = [ 1 => false ];
 		$assocCount    = 0;
@@ -174,8 +188,10 @@ class ArrayComplexitySniff implements Sniff {
 			}
 		}
 
-		$this->checkDepth( $phpcsFile, $stackPtr, $maxAssocCount );
-		$this->checkKeys( $phpcsFile, $stackPtr, $topLevelKeys );
+		return [
+			'depth' => $maxAssocCount,
+			'keys'  => $topLevelKeys,
+		];
 	}
 
 	/**

--- a/Apermo/Sniffs/DataStructures/ArrayComplexitySniff.php
+++ b/Apermo/Sniffs/DataStructures/ArrayComplexitySniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Discourage overly complex array structures.
+ * Discourages overly complex array structures.
  *
  * @package Apermo\Sniffs\DataStructures
  */
@@ -142,7 +142,7 @@ class ArrayComplexitySniff implements Sniff {
 	}
 
 	/**
-	 * Analyze an array for associative nesting depth and key count.
+	 * Analyzes an array for associative nesting depth and key count.
 	 *
 	 * @param File                    $phpcsFile The file being scanned.
 	 * @param int                     $stackPtr  The position of the array token (for reporting).
@@ -242,7 +242,7 @@ class ArrayComplexitySniff implements Sniff {
 	}
 
 	/**
-	 * Report on associative nesting depth.
+	 * Reports on associative nesting depth.
 	 *
 	 * @param File $phpcsFile     The file being scanned.
 	 * @param int  $stackPtr      The position to report at.
@@ -267,7 +267,7 @@ class ArrayComplexitySniff implements Sniff {
 	}
 
 	/**
-	 * Report on top-level key count.
+	 * Reports on top-level key count.
 	 *
 	 * @param File $phpcsFile    The file being scanned.
 	 * @param int  $stackPtr     The position to report at.
@@ -292,7 +292,7 @@ class ArrayComplexitySniff implements Sniff {
 	}
 
 	/**
-	 * Inspect a function/method/closure signature for complex parameter shapes.
+	 * Inspects a function/method/closure signature for complex parameter shapes.
 	 *
 	 * @param File $phpcsFile The file being scanned.
 	 * @param int  $stackPtr  Position of the T_FUNCTION / T_CLOSURE token.
@@ -303,7 +303,7 @@ class ArrayComplexitySniff implements Sniff {
 	}
 
 	/**
-	 * Flag parameters whose default value is a complex array literal.
+	 * Flags parameters whose default value is a complex array literal.
 	 *
 	 * @param File $phpcsFile The file being scanned.
 	 * @param int  $stackPtr  Position of the T_FUNCTION / T_CLOSURE token.
@@ -345,7 +345,7 @@ class ArrayComplexitySniff implements Sniff {
 	}
 
 	/**
-	 * Flag parameters whose `@param array{...}` docblock shape is complex.
+	 * Flags parameters whose `@param array{...}` docblock shape is complex.
 	 *
 	 * Parses PHPStan/Psalm shape syntax — splits top-level entries by
 	 * comma (respecting nested braces) for the key count, and recurses
@@ -402,7 +402,7 @@ class ArrayComplexitySniff implements Sniff {
 	}
 
 	/**
-	 * Report parameter-shape violations.
+	 * Reports parameter-shape violations.
 	 *
 	 * @param File                          $phpcsFile The file being scanned.
 	 * @param int                           $reportAt  Token position to attach the message to.
@@ -430,7 +430,7 @@ class ArrayComplexitySniff implements Sniff {
 	}
 
 	/**
-	 * Concatenate all T_DOC_COMMENT_STRING tokens belonging to a single tag.
+	 * Concatenates all T_DOC_COMMENT_STRING tokens belonging to a single tag.
 	 *
 	 * Multi-line tag values (e.g. a shape split across lines) are joined
 	 * with spaces, so `extractArrayShapeBody()` can operate on a single
@@ -456,7 +456,7 @@ class ArrayComplexitySniff implements Sniff {
 	}
 
 	/**
-	 * Extract the body of the first `array{...}` or `list{...}` shape in $content.
+	 * Extracts the body of the first `array{...}` or `list{...}` shape in $content.
 	 *
 	 * Returns the content between the outer `{` and its matching `}`,
 	 * or null if no shape is present or the braces are unbalanced.
@@ -485,7 +485,7 @@ class ArrayComplexitySniff implements Sniff {
 	}
 
 	/**
-	 * Extract the first `$name` token from $content.
+	 * Extracts the first `$name` token from $content.
 	 */
 	private function extractParamName( string $content ): string {
 		if ( preg_match( '/\$(\w+)/', $content, $match ) === 1 ) {
@@ -496,7 +496,7 @@ class ArrayComplexitySniff implements Sniff {
 	}
 
 	/**
-	 * Count top-level entries and max nesting depth of an array-shape body.
+	 * Counts top-level entries and max nesting depth of an array-shape body.
 	 *
 	 * Walks $body character by character, tracking brace depth. Commas at
 	 * depth 0 separate top-level entries. Nested `{...}` blocks are

--- a/Apermo/Sniffs/Formatting/ConsistentAssignmentAlignmentSniff.php
+++ b/Apermo/Sniffs/Formatting/ConsistentAssignmentAlignmentSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Enforce consistent alignment within assignment groups.
+ * Enforces consistent alignment within assignment groups.
  *
  * @package Apermo\Sniffs\Formatting
  */
@@ -97,7 +97,7 @@ class ConsistentAssignmentAlignmentSniff implements Sniff {
 	}
 
 	/**
-	 * Find the first assignment token on a given line, searching from a position.
+	 * Finds the first assignment token on a given line, searching from a position.
 	 *
 	 * @param File $phpcsFile The file being scanned.
 	 * @param int  $line      The line number.
@@ -129,7 +129,7 @@ class ConsistentAssignmentAlignmentSniff implements Sniff {
 	}
 
 	/**
-	 * Collect consecutive assignment statements into a group.
+	 * Collects consecutive assignment statements into a group.
 	 *
 	 * @param File $phpcsFile The file being scanned.
 	 * @param int  $stackPtr  The first assignment token.
@@ -172,7 +172,7 @@ class ConsistentAssignmentAlignmentSniff implements Sniff {
 	}
 
 	/**
-	 * Find an assignment token on the next consecutive line.
+	 * Finds an assignment token on the next consecutive line.
 	 *
 	 * Returns false if the next line is blank, has no assignment,
 	 * or is inside parentheses (for loops etc).
@@ -228,7 +228,7 @@ class ConsistentAssignmentAlignmentSniff implements Sniff {
 	}
 
 	/**
-	 * Measure spaces between end of LHS and the assignment operator.
+	 * Measures spaces between end of LHS and the assignment operator.
 	 *
 	 * @param File $phpcsFile The file being scanned.
 	 * @param int  $assignPtr The assignment token position.
@@ -256,7 +256,7 @@ class ConsistentAssignmentAlignmentSniff implements Sniff {
 	}
 
 	/**
-	 * Check consistency within a group and report violations.
+	 * Checks consistency within a group and report violations.
 	 *
 	 * Two valid styles:
 	 * - Single-space: all assignments have exactly 1 space before `=`
@@ -397,7 +397,7 @@ class ConsistentAssignmentAlignmentSniff implements Sniff {
 	}
 
 	/**
-	 * Get the stack pointer past the last member of a group.
+	 * Gets the stack pointer past the last member of a group.
 	 *
 	 * @param array<int, array{ptr: int, spaces: int, column: int, line: int, lhs_end: int}> $group    The collected group.
 	 * @param int                                                                            $stackPtr Fallback position.

--- a/Apermo/Sniffs/Functions/ForbiddenNestedClosureSniff.php
+++ b/Apermo/Sniffs/Functions/ForbiddenNestedClosureSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Forbid nested closures and arrow functions.
+ * Forbids nested closures and arrow functions.
  *
  * @package Apermo\Sniffs\Functions
  */

--- a/Apermo/Sniffs/Helpers/FunctionCallDetectorTrait.php
+++ b/Apermo/Sniffs/Helpers/FunctionCallDetectorTrait.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Trait for detecting genuine function calls vs. definitions and method calls.
+ * Detects genuine function calls vs. definitions and method calls.
  *
  * @package Apermo\Sniffs\Helpers
  */

--- a/Apermo/Sniffs/Hooks/RequireHookDocBlockSniff.php
+++ b/Apermo/Sniffs/Hooks/RequireHookDocBlockSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Require PHPDoc blocks before WordPress hook invocations.
+ * Requires PHPDoc blocks before WordPress hook invocations.
  *
  * @package Apermo\Sniffs\Hooks
  */
@@ -84,7 +84,7 @@ class RequireHookDocBlockSniff implements Sniff {
 	}
 
 	/**
-	 * Search backward from statement start for a doc block.
+	 * Searches backward from statement start for a doc block.
 	 *
 	 * @param File $phpcsFile      The file being scanned.
 	 * @param int  $statementStart The position of the statement start.
@@ -116,7 +116,7 @@ class RequireHookDocBlockSniff implements Sniff {
 	}
 
 	/**
-	 * Validate the doc block has required @param and @return tags.
+	 * Validates the doc block has required @param and @return tags.
 	 *
 	 * @param File                        $phpcsFile The file being scanned.
 	 * @param int                         $stackPtr  The hook function token position.
@@ -170,7 +170,7 @@ class RequireHookDocBlockSniff implements Sniff {
 	}
 
 	/**
-	 * Count hook arguments beyond the hook name.
+	 * Counts hook arguments beyond the hook name.
 	 *
 	 * For _ref_array and _deprecated variants, the second arg is an
 	 * args array. Empty array literals ([] or array()) are treated

--- a/Apermo/Sniffs/Namespaces/GlobalFunctionQualificationSniff.php
+++ b/Apermo/Sniffs/Namespaces/GlobalFunctionQualificationSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Enforce correct function qualification in namespaced code.
+ * Enforces correct function qualification in namespaced code.
  *
  * @package Apermo\Sniffs\Namespaces
  */
@@ -130,7 +130,7 @@ class GlobalFunctionQualificationSniff implements Sniff {
 	}
 
 	/**
-	 * Check if the token is inside a namespace declaration.
+	 * Checks if the token is inside a namespace declaration.
 	 *
 	 * @param File $phpcsFile The file being scanned.
 	 * @param int  $stackPtr  The position of the current token.
@@ -152,7 +152,7 @@ class GlobalFunctionQualificationSniff implements Sniff {
 	}
 
 	/**
-	 * Check if a function is a PHP native (internal) function.
+	 * Checks if a function is a PHP native (internal) function.
 	 *
 	 * @param string $name The function name.
 	 *

--- a/Apermo/Sniffs/NamingConventions/MinimumVariableNameLengthSniff.php
+++ b/Apermo/Sniffs/NamingConventions/MinimumVariableNameLengthSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Enforce a minimum variable name length.
+ * Enforces a minimum variable name length.
  *
  * @package Apermo\Sniffs\NamingConventions
  */

--- a/Apermo/Sniffs/Operators/DisallowPreIncrementDecrementSniff.php
+++ b/Apermo/Sniffs/Operators/DisallowPreIncrementDecrementSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Disallow pre-increment/pre-decrement in favor of post-increment/post-decrement.
+ * Disallows pre-increment/pre-decrement in favor of post-increment/post-decrement.
  *
  * @package Apermo\Sniffs\Operators
  */
@@ -83,7 +83,7 @@ class DisallowPreIncrementDecrementSniff implements Sniff {
 	}
 
 	/**
-	 * Find the last token of a complex identifier.
+	 * Finds the last token of a complex identifier.
 	 *
 	 * Walks through object operators (->), double colons (::),
 	 * property/method names, and array brackets.

--- a/Apermo/Sniffs/PHP/ExitUsageSniff.php
+++ b/Apermo/Sniffs/PHP/ExitUsageSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Enforce exit() over die and bare exit.
+ * Enforces exit() over die and bare exit.
  *
  * @package Apermo\Sniffs\PHP
  */

--- a/Apermo/Sniffs/PHP/ExplainCommentedOutCodeSniff.php
+++ b/Apermo/Sniffs/PHP/ExplainCommentedOutCodeSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Require explained doc-blocks before commented-out code.
+ * Requires explained doc-blocks before commented-out code.
  *
  * @package Apermo\Sniffs\PHP
  */
@@ -103,7 +103,7 @@ class ExplainCommentedOutCodeSniff implements Sniff {
 	}
 
 	/**
-	 * Collect consecutive // comment lines into a single block.
+	 * Collects consecutive // comment lines into a single block.
 	 *
 	 * @param File $phpcsFile The file being scanned.
 	 * @param int  $stackPtr  Starting token position.
@@ -146,7 +146,7 @@ class ExplainCommentedOutCodeSniff implements Sniff {
 	}
 
 	/**
-	 * Search backwards for a doc-block within the allowed gap.
+	 * Searches backwards for a doc-block within the allowed gap.
 	 *
 	 * @param File $phpcsFile The file being scanned.
 	 * @param int  $stackPtr  Position of the first code comment token.
@@ -202,7 +202,7 @@ class ExplainCommentedOutCodeSniff implements Sniff {
 	}
 
 	/**
-	 * Check if the doc-block content starts with a recognized keyword.
+	 * Checks if the doc-block content starts with a recognized keyword.
 	 *
 	 * @param string $doc_content The extracted doc-block text.
 	 *
@@ -219,7 +219,7 @@ class ExplainCommentedOutCodeSniff implements Sniff {
 	}
 
 	/**
-	 * Determine if stripped comment content looks like PHP code.
+	 * Determines if stripped comment content looks like PHP code.
 	 *
 	 * Uses the same heuristic as Squiz.PHP.CommentedOutCode.
 	 *

--- a/Apermo/Sniffs/PHP/ForbiddenObjectCastSniff.php
+++ b/Apermo/Sniffs/PHP/ForbiddenObjectCastSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Discourage (object) casts that produce stdClass instances.
+ * Discourages (object) casts that produce stdClass instances.
  *
  * @package Apermo\Sniffs\PHP
  */

--- a/Apermo/Sniffs/PHP/NoFilterSanitizeStringSniff.php
+++ b/Apermo/Sniffs/PHP/NoFilterSanitizeStringSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Flag deprecated FILTER_SANITIZE_STRING usage.
+ * Flags deprecated FILTER_SANITIZE_STRING usage.
  *
  * @package Apermo\Sniffs\PHP
  */

--- a/Apermo/Sniffs/PHP/PreferModernStringFunctionsSniff.php
+++ b/Apermo/Sniffs/PHP/PreferModernStringFunctionsSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Flag strpos/strstr comparison patterns replaceable by modern PHP 8 functions.
+ * Flags strpos/strstr comparison patterns replaceable by modern PHP 8 functions.
  *
  * @package Apermo\Sniffs\PHP
  */
@@ -83,7 +83,7 @@ class PreferModernStringFunctionsSniff implements Sniff {
 	}
 
 	/**
-	 * Check for pattern: strpos/strstr(...) === false|0.
+	 * Checks for pattern: strpos/strstr(...) === false|0.
 	 *
 	 * @param File   $phpcsFile The file being scanned.
 	 * @param int    $stackPtr  Position of the function name token.
@@ -113,7 +113,7 @@ class PreferModernStringFunctionsSniff implements Sniff {
 	}
 
 	/**
-	 * Check for reversed pattern: false|0 === strpos/strstr(...).
+	 * Checks for reversed pattern: false|0 === strpos/strstr(...).
 	 *
 	 * @param File   $phpcsFile The file being scanned.
 	 * @param int    $stackPtr  Position of the function name token.
@@ -142,7 +142,7 @@ class PreferModernStringFunctionsSniff implements Sniff {
 	}
 
 	/**
-	 * Check the operand and report a violation if it matches false or 0.
+	 * Checks the operand and report a violation if it matches false or 0.
 	 *
 	 * @param File   $phpcsFile The file being scanned.
 	 * @param int    $stackPtr  Position of the function name token.
@@ -184,7 +184,7 @@ class PreferModernStringFunctionsSniff implements Sniff {
 	}
 
 	/**
-	 * Report a violation as error or warning based on configuration.
+	 * Reports a violation as error or warning based on configuration.
 	 *
 	 * @param File   $phpcsFile The file being scanned.
 	 * @param int    $stackPtr  Position to report on.

--- a/Apermo/Sniffs/PHP/RequireAbsoluteIncludePathSniff.php
+++ b/Apermo/Sniffs/PHP/RequireAbsoluteIncludePathSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Flag require/include with relative paths.
+ * Flags require/include with relative paths.
  *
  * @package Apermo\Sniffs\PHP
  */

--- a/Apermo/Sniffs/PHP/RequireNotIncludeSniff.php
+++ b/Apermo/Sniffs/PHP/RequireNotIncludeSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Enforce require/require_once over include/include_once.
+ * Enforces require/require_once over include/include_once.
  *
  * @package Apermo\Sniffs\PHP
  */

--- a/Apermo/Sniffs/PHP/SapiDependentFeaturesSniff.php
+++ b/Apermo/Sniffs/PHP/SapiDependentFeaturesSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Flag SAPI-dependent PHP features.
+ * Flags SAPI-dependent PHP features.
  *
  * @package Apermo\Sniffs\PHP
  */

--- a/Apermo/Sniffs/WhiteSpace/MultipleEmptyLinesSniff.php
+++ b/Apermo/Sniffs/WhiteSpace/MultipleEmptyLinesSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Disallow multiple consecutive empty lines outside functions.
+ * Disallows multiple consecutive empty lines outside functions.
  *
  * @package Apermo\Sniffs\WhiteSpace
  */

--- a/Apermo/Sniffs/WordPress/AbstractPostContextSniff.php
+++ b/Apermo/Sniffs/WordPress/AbstractPostContextSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Abstract base for post-context sniffs.
+ * Provides the abstract base for post-context sniffs.
  *
  * @package Apermo\Sniffs\WordPress
  */
@@ -13,7 +13,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
- * Shared utilities for sniffs that check implicit global $post access.
+ * Provides shared utilities for sniffs that check implicit global $post access.
  *
  * Provides scope detection and argument counting helpers used by
  * GlobalPostAccessSniff and ImplicitPostFunctionSniff.

--- a/Apermo/Sniffs/WordPress/GlobalPostAccessSniff.php
+++ b/Apermo/Sniffs/WordPress/GlobalPostAccessSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Flag global $post usage inside functions.
+ * Flags global $post usage inside functions.
  *
  * @package Apermo\Sniffs\WordPress
  */

--- a/Apermo/Sniffs/WordPress/ImplicitPostFunctionSniff.php
+++ b/Apermo/Sniffs/WordPress/ImplicitPostFunctionSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Flag WordPress functions that implicitly access global $post.
+ * Flags WordPress functions that implicitly access global $post.
  *
  * @package Apermo\Sniffs\WordPress
  */

--- a/Apermo/Sniffs/WordPress/NoAdminAjaxSniff.php
+++ b/Apermo/Sniffs/WordPress/NoAdminAjaxSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Flag add_action() calls registering wp_ajax_ hooks.
+ * Flags add_action() calls registering wp_ajax_ hooks.
  *
  * @package Apermo\Sniffs\WordPress
  */
@@ -78,7 +78,7 @@ class NoAdminAjaxSniff implements Sniff {
 	}
 
 	/**
-	 * Extract the hook name string from the parameter tokens.
+	 * Extracts the hook name string from the parameter tokens.
 	 *
 	 * Handles single-quoted and double-quoted strings. Returns null for
 	 * variable or dynamic hook names that cannot be statically analyzed.

--- a/Apermo/Sniffs/WordPress/NoHardcodedTableNamesSniff.php
+++ b/Apermo/Sniffs/WordPress/NoHardcodedTableNamesSniff.php
@@ -28,12 +28,16 @@ class NoHardcodedTableNamesSniff implements Sniff {
 
 	/**
 	 * SQL keywords after which a bare identifier is a table name.
-	 * Matches the keyword followed by a hardcoded identifier that is
+	 *
+	 * `TABLE` alone is too ambiguous (matches `<table class=...>` HTML),
+	 * so it only qualifies when preceded by a DDL verb
+	 * (CREATE/DROP/ALTER/TRUNCATE/RENAME), with an optional `IF [NOT] EXISTS`
+	 * clause. Matches the keyword followed by a hardcoded identifier that is
 	 * not a placeholder (%s, %i, %1$s) or an interpolation ({$...}).
 	 *
 	 * @var string
 	 */
-	private const PATTERN = '/\b(?:FROM|JOIN|INTO|UPDATE|TABLE)\s+(?!%[sid]|%\d+\$[sid])([a-zA-Z_]\w*)\b/i';
+	private const PATTERN = '/\b(?:FROM|JOIN|INTO|UPDATE|(?:CREATE(?:\s+TEMPORARY)?|DROP|ALTER|TRUNCATE|RENAME)\s+TABLE(?:\s+IF\s+(?:NOT\s+)?EXISTS)?)\s+(?!%[sid]|%\d+\$[sid])([a-zA-Z_]\w*)\b/i';
 
 	/**
 	 * Matches $wpdb->prefix interpolation followed by a table name

--- a/Apermo/Sniffs/WordPress/NoHardcodedTableNamesSniff.php
+++ b/Apermo/Sniffs/WordPress/NoHardcodedTableNamesSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Flag hardcoded table names in SQL strings.
+ * Flags hardcoded table names in SQL strings.
  *
  * @package Apermo\Sniffs\WordPress
  */

--- a/Apermo/Sniffs/WordPress/NoHardcodedTableNamesSniff.php
+++ b/Apermo/Sniffs/WordPress/NoHardcodedTableNamesSniff.php
@@ -40,6 +40,21 @@ class NoHardcodedTableNamesSniff implements Sniff {
 	private const PATTERN = '/\b(?:FROM|JOIN|INTO|UPDATE|(?:CREATE(?:\s+TEMPORARY)?|DROP|ALTER|TRUNCATE|RENAME)\s+TABLE(?:\s+IF\s+(?:NOT\s+)?EXISTS)?)\s+(?!%[sid]|%\d+\$[sid])([a-zA-Z_]\w*)\b/i';
 
 	/**
+	 * SQL-context precondition. Only run the table-name regex when the
+	 * string actually looks like SQL — i.e. contains SELECT/WHERE/SET/
+	 * VALUES/HAVING/LIMIT/ORDER BY/GROUP BY, or a double-word idiom like
+	 * INSERT INTO / DELETE FROM / UPDATE {name} SET, or a DDL TABLE clause.
+	 *
+	 * Eliminates false positives on English prose ("lessons from a team",
+	 * "posts from the admin") and WP UI labels ("Update Revision Tag")
+	 * that happen to contain one of the FROM/JOIN/INTO/UPDATE anchors
+	 * next to another word.
+	 *
+	 * @var string
+	 */
+	private const SQL_CONTEXT_PATTERN = '/\b(?:SELECT|INSERT\s+INTO|DELETE\s+FROM|UPDATE\s+\S+\s+SET|WHERE|VALUES|ORDER\s+BY|GROUP\s+BY|LIMIT|HAVING|(?:CREATE(?:\s+TEMPORARY)?|DROP|ALTER|TRUNCATE|RENAME)\s+TABLE)\b/i';
+
+	/**
 	 * Matches $wpdb->prefix interpolation followed by a table name
 	 * in double-quoted strings: "{$wpdb->prefix}tablename".
 	 *
@@ -78,6 +93,11 @@ class NoHardcodedTableNamesSniff implements Sniff {
 	public function process( File $phpcsFile, $stackPtr ) {
 		$tokens  = $phpcsFile->getTokens();
 		$content = $tokens[ $stackPtr ]['content'];
+
+		// Fast-fail for strings that clearly are not SQL.
+		if ( preg_match( self::SQL_CONTEXT_PATTERN, $content ) !== 1 ) {
+			return;
+		}
 
 		// Check for hardcoded table names after SQL keywords.
 		if ( preg_match( self::PATTERN, $content, $matches ) === 1 ) {

--- a/Apermo/Sniffs/WordPress/PreferWpdbIdentifierPlaceholderSniff.php
+++ b/Apermo/Sniffs/WordPress/PreferWpdbIdentifierPlaceholderSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Flag %s placeholder for identifiers in $wpdb->prepare().
+ * Flags %s placeholder for identifiers in $wpdb->prepare().
  *
  * @package Apermo\Sniffs\WordPress
  */
@@ -67,7 +67,7 @@ class PreferWpdbIdentifierPlaceholderSniff implements Sniff {
 	}
 
 	/**
-	 * Check if the token is part of a $wpdb->prepare() call.
+	 * Checks if the token is part of a $wpdb->prepare() call.
 	 *
 	 * Walks back to find $wpdb->prepare pattern before the current
 	 * string token.

--- a/Apermo/Sniffs/WordPress/RequireOptionAutoloadSniff.php
+++ b/Apermo/Sniffs/WordPress/RequireOptionAutoloadSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Require explicit autoload parameter on option functions.
+ * Requires explicit autoload parameter on option functions.
  *
  * @package Apermo\Sniffs\WordPress
  */

--- a/Apermo/Sniffs/WordPress/RequireRestPermissionCallbackSniff.php
+++ b/Apermo/Sniffs/WordPress/RequireRestPermissionCallbackSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Require permission_callback in register_rest_route() calls.
+ * Requires permission_callback in register_rest_route() calls.
  *
  * @package Apermo\Sniffs\WordPress
  */
@@ -84,7 +84,7 @@ class RequireRestPermissionCallbackSniff implements Sniff {
 	}
 
 	/**
-	 * Check if the args parameter contains a 'permission_callback' key.
+	 * Checks if the args parameter contains a 'permission_callback' key.
 	 *
 	 * Handles both single route definitions and nested multi-route arrays.
 	 * For nested arrays, every sub-array must contain the key.
@@ -121,7 +121,7 @@ class RequireRestPermissionCallbackSniff implements Sniff {
 	}
 
 	/**
-	 * Check that every inner array in a nested route definition has permission_callback.
+	 * Checks that every inner array in a nested route definition has permission_callback.
 	 *
 	 * @param File $phpcsFile The file being scanned.
 	 * @param int  $opener    The outer array opener token position.
@@ -167,7 +167,7 @@ class RequireRestPermissionCallbackSniff implements Sniff {
 	}
 
 	/**
-	 * Scan a token range for 'permission_callback' used as an array key.
+	 * Scans a token range for 'permission_callback' used as an array key.
 	 *
 	 * @param File $phpcsFile The file being scanned.
 	 * @param int  $start     Start token position.
@@ -198,7 +198,7 @@ class RequireRestPermissionCallbackSniff implements Sniff {
 	}
 
 	/**
-	 * Get the opener and closer positions of the array in a parameter.
+	 * Gets the opener and closer positions of the array in a parameter.
 	 *
 	 * @param File                                    $phpcsFile The file being scanned.
 	 * @param array{start: int, end: int, raw: string} $param     Parameter info.
@@ -223,7 +223,7 @@ class RequireRestPermissionCallbackSniff implements Sniff {
 	}
 
 	/**
-	 * Check if the parameter contains an array literal ([ or array().
+	 * Checks if the parameter contains an array literal ([ or array().
 	 *
 	 * @param File                                    $phpcsFile The file being scanned.
 	 * @param array{start: int, end: int, raw: string} $param     Parameter info.
@@ -246,7 +246,7 @@ class RequireRestPermissionCallbackSniff implements Sniff {
 	}
 
 	/**
-	 * Strip surrounding quotes from a string token.
+	 * Strips surrounding quotes from a string token.
 	 *
 	 * @param string $content The token content.
 	 *

--- a/Apermo/Sniffs/WordPress/RequireWpErrorHandlingSniff.php
+++ b/Apermo/Sniffs/WordPress/RequireWpErrorHandlingSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Flag unchecked WP_Error-returning function calls.
+ * Flags unchecked WP_Error-returning function calls.
  *
  * @package Apermo\Sniffs\WordPress
  */
@@ -98,7 +98,7 @@ class RequireWpErrorHandlingSniff implements Sniff {
 	}
 
 	/**
-	 * Get the variable name the function result is assigned to.
+	 * Gets the variable name the function result is assigned to.
 	 *
 	 * Looks for pattern: $var = func_name(
 	 *
@@ -126,7 +126,7 @@ class RequireWpErrorHandlingSniff implements Sniff {
 	}
 
 	/**
-	 * Find the end of the enclosing scope.
+	 * Finds the end of the enclosing scope.
 	 *
 	 * @param File $phpcsFile The file being scanned.
 	 * @param int  $stackPtr  Current position.
@@ -146,7 +146,7 @@ class RequireWpErrorHandlingSniff implements Sniff {
 	}
 
 	/**
-	 * Check if is_wp_error($var) is called in the scope.
+	 * Checks if is_wp_error($var) is called in the scope.
 	 *
 	 * @param File   $phpcsFile The file being scanned.
 	 * @param int    $stackPtr  Position after which to search.

--- a/Apermo/Sniffs/WordPress/RequireWpErrorHandlingSniff.php
+++ b/Apermo/Sniffs/WordPress/RequireWpErrorHandlingSniff.php
@@ -40,15 +40,12 @@ class RequireWpErrorHandlingSniff implements Sniff {
 		'wp_safe_remote_head' => true,
 		'wp_insert_post'     => true,
 		'wp_update_post'     => true,
-		'wp_delete_post'     => true,
 		'wp_insert_term'     => true,
 		'wp_update_term'     => true,
 		'wp_insert_user'     => true,
 		'wp_update_user'     => true,
-		'wp_upload_bits'     => true,
 		'wp_crop_image'      => true,
 		'media_handle_upload' => true,
-		'wp_mail'            => true,
 	];
 
 	/**

--- a/Apermo/Sniffs/WordPress/SwitchToBlogRequiresRestoreSniff.php
+++ b/Apermo/Sniffs/WordPress/SwitchToBlogRequiresRestoreSniff.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Flag switch_to_blog() without restore_current_blog().
+ * Flags switch_to_blog() without restore_current_blog().
  *
  * @package Apermo\Sniffs\WordPress
  */
@@ -69,7 +69,7 @@ class SwitchToBlogRequiresRestoreSniff implements Sniff {
 	}
 
 	/**
-	 * Find the end of the enclosing scope.
+	 * Finds the end of the enclosing scope.
 	 *
 	 * @param File $phpcsFile The file being scanned.
 	 * @param int  $stackPtr  Current position.
@@ -91,7 +91,7 @@ class SwitchToBlogRequiresRestoreSniff implements Sniff {
 	}
 
 	/**
-	 * Check if restore_current_blog() is called after $stackPtr within the scope.
+	 * Checks if restore_current_blog() is called after $stackPtr within the scope.
 	 *
 	 * @param File $phpcsFile The file being scanned.
 	 * @param int  $stackPtr  Position of switch_to_blog().

--- a/Apermo/Tests/Arrays/ConsistentDoubleArrowAlignmentUnitTest.php
+++ b/Apermo/Tests/Arrays/ConsistentDoubleArrowAlignmentUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the ConsistentDoubleArrowAlignment sniff.
+ * Tests the ConsistentDoubleArrowAlignment sniff.
  *
  * @package Apermo\Tests\Arrays
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\Arrays;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.Arrays.ConsistentDoubleArrowAlignment.
+ * Tests Apermo.Arrays.ConsistentDoubleArrowAlignment.
  */
 class ConsistentDoubleArrowAlignmentUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/CodeQuality/ExcessiveParameterCountUnitTest.php
+++ b/Apermo/Tests/CodeQuality/ExcessiveParameterCountUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the ExcessiveParameterCount sniff.
+ * Tests the ExcessiveParameterCount sniff.
  *
  * @package Apermo\Tests\CodeQuality
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\CodeQuality;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.CodeQuality.ExcessiveParameterCount.
+ * Tests Apermo.CodeQuality.ExcessiveParameterCount.
  */
 class ExcessiveParameterCountUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/DataStructures/ArrayComplexityUnitTest.inc
+++ b/Apermo/Tests/DataStructures/ArrayComplexityUnitTest.inc
@@ -5,27 +5,36 @@ $flat = [ 'a' => 1, 'b' => 2 ];
 // OK — nested but numeric (list of lists).
 $grid = [ [ 1, 2 ], [ 3, 4 ] ];
 
-// OK — 2 associative levels (equals warnDepth=2, not exceeded).
-$shallow = [ 'db' => [ 'host' => 'localhost' ] ];
-
-// WARNING TooDeep — 3 associative levels.
-$deep = [ 'a' => [ 'b' => [ 'c' => 1 ] ] ];
-
-// ERROR TooDeepError — 5 associative levels.
-$veryDeep = [ 'a' => [ 'b' => [ 'c' => [ 'd' => [ 'e' => 1 ] ] ] ] ];
-
-// WARNING TooManyKeys — 6 keys.
-$user = [
-	'id'       => 1,
-	'name'     => 'John',
-	'email'    => 'john@example.com',
-	'role'     => 'admin',
-	'active'   => true,
-	'verified' => true,
+// OK — 3 associative levels (equals warnDepth=3, not exceeded).
+// Mirrors WP_Query's `meta_query` shape, which is canonical WP usage.
+$wp_query_with_meta = [
+	'post_type'  => 'post',
+	'meta_query' => [
+		'relation' => 'AND',
+		[ 'key' => 'foo', 'compare' => 'EXISTS' ],
+		[ 'key' => 'bar', 'compare' => 'EXISTS' ],
+	],
 ];
 
-// ERROR TooManyKeysError — 11 keys.
-$big = [
+// OK — typical WP_Query arg set (7 keys, below warnKeys=10).
+$query_args = [
+	'post_type'      => 'any',
+	'post_status'    => 'any',
+	'posts_per_page' => -1,
+	'fields'         => 'ids',
+	'meta_key'       => 'x',
+	'meta_value'     => 'y',
+	'no_found_rows'  => true,
+];
+
+// WARNING TooDeep — 4 associative levels.
+$deep4 = [ 'a' => [ 'b' => [ 'c' => [ 'd' => 1 ] ] ] ];
+
+// ERROR TooDeepError — 6 associative levels.
+$deep6 = [ 'a' => [ 'b' => [ 'c' => [ 'd' => [ 'e' => [ 'f' => 1 ] ] ] ] ] ];
+
+// WARNING TooManyKeys — 11 keys.
+$many11 = [
 	'k1'  => 1,
 	'k2'  => 2,
 	'k3'  => 3,
@@ -39,41 +48,75 @@ $big = [
 	'k11' => 11,
 ];
 
+// ERROR TooManyKeysError — 21 keys.
+$many21 = [
+	'k01' => 1,
+	'k02' => 2,
+	'k03' => 3,
+	'k04' => 4,
+	'k05' => 5,
+	'k06' => 6,
+	'k07' => 7,
+	'k08' => 8,
+	'k09' => 9,
+	'k10' => 10,
+	'k11' => 11,
+	'k12' => 12,
+	'k13' => 13,
+	'k14' => 14,
+	'k15' => 15,
+	'k16' => 16,
+	'k17' => 17,
+	'k18' => 18,
+	'k19' => 19,
+	'k20' => 20,
+	'k21' => 21,
+];
+
 // OK — numeric array with many elements.
-$numbers = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ];
+$numbers = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 ];
 
 // OK — array() long syntax, few keys.
-$longSyntax = array( 'a' => 1, 'b' => 2 );
+$long_syntax = array( 'a' => 1, 'b' => 2 );
 
 // OK — empty array.
 $empty = [];
 
-// WARNING TooDeep — long syntax, 3 associative levels.
-$deepLong = array( 'a' => array( 'b' => array( 'c' => 1 ) ) );
+// WARNING TooDeep — long syntax, 4 associative levels.
+$deep_long4 = array( 'a' => array( 'b' => array( 'c' => array( 'd' => 1 ) ) ) );
 
 // WARNING TooDeep + WARNING TooManyKeys — both checks fire independently.
 $both = [
-	'a' => [ 'b' => [ 'c' => 1 ] ],
-	'd' => 2,
-	'e' => 3,
-	'f' => 4,
-	'g' => 5,
-	'h' => 6,
+	'a'   => [ 'b' => [ 'c' => [ 'd' => 1 ] ] ],
+	'k2'  => 2,
+	'k3'  => 3,
+	'k4'  => 4,
+	'k5'  => 5,
+	'k6'  => 6,
+	'k7'  => 7,
+	'k8'  => 8,
+	'k9'  => 9,
+	'k10' => 10,
+	'k11' => 11,
 ];
 
 // OK — non-associative wrapper around associative inner arrays.
 $mixed = [ [ 'a' => 1 ], [ 'b' => 2 ] ];
 
-// OK — function call inside array (close paren owner is T_STRING, not T_ARRAY).
+// OK — function call inside array.
 $config = [ 'merged' => array_merge( [ 'a' => 1 ], [ 'b' => 2 ] ) ];
 
 // OK — numeric array nested inside associative array.
 $items = [ 'list' => [ 1, 2, 3 ] ];
 
-// OK — multiple numeric arrays nested inside associative array.
-$grid = [
-	'rows' => [
-		[ 1, 2 ],
-		[ 3, 4 ],
-	],
+// OK — variable-extraction pattern: complex sub-array is lifted to its own variable,
+// keeping both literals within warnDepth=3.
+$meta_query_body = [
+	'relation' => 'AND',
+	[ 'key' => 'foo', 'compare' => 'EXISTS' ],
+	[ 'key' => 'bar', 'compare' => 'EXISTS' ],
+];
+$extracted_args = [
+	'post_type'  => 'any',
+	'meta_query' => $meta_query_body,
 ];

--- a/Apermo/Tests/DataStructures/ArrayComplexityUnitTest.inc
+++ b/Apermo/Tests/DataStructures/ArrayComplexityUnitTest.inc
@@ -120,3 +120,102 @@ $extracted_args = [
 	'post_type'  => 'any',
 	'meta_query' => $meta_query_body,
 ];
+
+// --- Parameter-signature checks (ComplexParameter*) --- //
+
+// ERROR ComplexParameterKeys — 6-key default value (> parameterMaxKeys=5).
+function with_wide_default( $opts = [
+	'k1' => 1,
+	'k2' => 2,
+	'k3' => 3,
+	'k4' => 4,
+	'k5' => 5,
+	'k6' => 6,
+] ) {
+	return $opts;
+}
+
+// ERROR ComplexParameterDepth — 3-level default value (> parameterMaxDepth=2).
+function with_deep_default( $opts = [ 'a' => [ 'b' => [ 'c' => 1 ] ] ] ) {
+	return $opts;
+}
+
+// OK — simple default (5 keys, depth 1).
+function with_simple_default( $opts = [ 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5 ] ) {
+	return $opts;
+}
+
+// OK — numeric default (no associative keys, depth still 0).
+function with_numeric_default( $opts = [ 1, 2, 3, 4, 5, 6 ] ) {
+	return $opts;
+}
+
+// OK — no default at all.
+function without_default( $opts ) {
+	return $opts;
+}
+
+// OK — scalar default.
+function with_scalar_default( $opts = 'x' ) {
+	return $opts;
+}
+
+/**
+ * ERROR ComplexParameterKeys — docblock shape with 6 top-level entries.
+ *
+ * @param array{a: int, b: int, c: int, d: int, e: int, f: int} $opts Options.
+ */
+function with_wide_shape( array $opts ) {
+	return $opts;
+}
+
+/**
+ * ERROR ComplexParameterDepth — docblock shape depth 3.
+ *
+ * @param array{a: array{b: array{c: int}}} $opts Options.
+ */
+function with_deep_shape( array $opts ) {
+	return $opts;
+}
+
+/**
+ * OK — docblock shape within limits (2 keys, depth 1).
+ *
+ * @param array{a: int, b: int} $opts Options.
+ */
+function with_simple_shape( array $opts ) {
+	return $opts;
+}
+
+/**
+ * OK — @param without array{} shape (just array type) is ignored.
+ *
+ * @param array $opts Options.
+ */
+function with_untyped_array( array $opts ) {
+	return $opts;
+}
+
+class ArrayComplexityMethodHost {
+	// ERROR ComplexParameterKeys — method with a wide array default.
+	public function method_with_wide_default( $opts = [
+		'k1' => 1,
+		'k2' => 2,
+		'k3' => 3,
+		'k4' => 4,
+		'k5' => 5,
+		'k6' => 6,
+	] ) {
+		return $opts;
+	}
+}
+
+// OK — closure with simple default.
+$simple_closure = function ( $opts = [ 'a' => 1 ] ) {
+	return $opts;
+};
+
+// ERROR ComplexParameterDepth — closure with deep default.
+$deep_closure = function ( $opts = [ 'a' => [ 'b' => [ 'c' => 1 ] ] ] ) {
+	return $opts;
+};

--- a/Apermo/Tests/DataStructures/ArrayComplexityUnitTest.inc
+++ b/Apermo/Tests/DataStructures/ArrayComplexityUnitTest.inc
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable Apermo.Commenting.DocSummaryStyle -- Test markers (ERROR/OK) aren't real docblocks.
 // OK — flat with few keys.
 $flat = [ 'a' => 1, 'b' => 2 ];
 

--- a/Apermo/Tests/DataStructures/ArrayComplexityUnitTest.inc
+++ b/Apermo/Tests/DataStructures/ArrayComplexityUnitTest.inc
@@ -220,3 +220,40 @@ $simple_closure = function ( $opts = [ 'a' => 1 ] ) {
 $deep_closure = function ( $opts = [ 'a' => [ 'b' => [ 'c' => 1 ] ] ] ) {
 	return $opts;
 };
+
+// ERROR ComplexParameterKeys — arrow function with wide array default (T_FN).
+$wide_arrow = fn( $opts = [
+	'k1' => 1,
+	'k2' => 2,
+	'k3' => 3,
+	'k4' => 4,
+	'k5' => 5,
+	'k6' => 6,
+] ) => $opts;
+
+/**
+ * OK — callable type's parenthesised commas must NOT inflate the key count.
+ *
+ * @param array{cb: callable(int, string): void, flag: bool} $opts Options.
+ */
+function with_callable_shape( array $opts ) {
+	return $opts;
+}
+
+/**
+ * OK — generic's angle-bracketed commas must NOT inflate the key count.
+ *
+ * @param array{items: Collection<int, string>, name: string} $opts Options.
+ */
+function with_generic_shape( array $opts ) {
+	return $opts;
+}
+
+/**
+ * OK — variable ($this) inside the shape must not be reported as the param name.
+ *
+ * @param array{self: $this, other: int} $opts Options.
+ */
+function with_this_in_shape( array $opts ) {
+	return $opts;
+}

--- a/Apermo/Tests/DataStructures/ArrayComplexityUnitTest.php
+++ b/Apermo/Tests/DataStructures/ArrayComplexityUnitTest.php
@@ -33,6 +33,7 @@ class ArrayComplexityUnitTest extends AbstractSniffUnitTest {
 			176 => 1,
 			202 => 1,
 			220 => 1,
+			225 => 1,
 		];
 	}
 

--- a/Apermo/Tests/DataStructures/ArrayComplexityUnitTest.php
+++ b/Apermo/Tests/DataStructures/ArrayComplexityUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the ArrayComplexity sniff.
+ * Tests the ArrayComplexity sniff.
  *
  * @package Apermo\Tests\DataStructures
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\DataStructures;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.DataStructures.ArrayComplexity.
+ * Tests Apermo.DataStructures.ArrayComplexity.
  */
 class ArrayComplexityUnitTest extends AbstractSniffUnitTest {
 
@@ -25,14 +25,14 @@ class ArrayComplexityUnitTest extends AbstractSniffUnitTest {
 	 */
 	protected function getErrorList( $testFile = '' ) {
 		return [
-			34  => 1,
-			52  => 1,
-			127 => 1,
-			139 => 1,
-			166 => 1,
-			175 => 1,
-			201 => 1,
-			219 => 1,
+			35  => 1,
+			53  => 1,
+			128 => 1,
+			140 => 1,
+			167 => 1,
+			176 => 1,
+			202 => 1,
+			220 => 1,
 		];
 	}
 
@@ -45,10 +45,10 @@ class ArrayComplexityUnitTest extends AbstractSniffUnitTest {
 	 */
 	protected function getWarningList( $testFile = '' ) {
 		return [
-			31 => 1,
-			37 => 1,
-			86 => 1,
-			89 => 2,
+			32 => 1,
+			38 => 1,
+			87 => 1,
+			90 => 2,
 		];
 	}
 }

--- a/Apermo/Tests/DataStructures/ArrayComplexityUnitTest.php
+++ b/Apermo/Tests/DataStructures/ArrayComplexityUnitTest.php
@@ -25,8 +25,14 @@ class ArrayComplexityUnitTest extends AbstractSniffUnitTest {
 	 */
 	protected function getErrorList( $testFile = '' ) {
 		return [
-			34 => 1,
-			52 => 1,
+			34  => 1,
+			52  => 1,
+			127 => 1,
+			139 => 1,
+			166 => 1,
+			175 => 1,
+			201 => 1,
+			219 => 1,
 		];
 	}
 

--- a/Apermo/Tests/DataStructures/ArrayComplexityUnitTest.php
+++ b/Apermo/Tests/DataStructures/ArrayComplexityUnitTest.php
@@ -25,8 +25,8 @@ class ArrayComplexityUnitTest extends AbstractSniffUnitTest {
 	 */
 	protected function getErrorList( $testFile = '' ) {
 		return [
-			15 => 1,
-			28 => 1,
+			34 => 1,
+			52 => 1,
 		];
 	}
 
@@ -39,10 +39,10 @@ class ArrayComplexityUnitTest extends AbstractSniffUnitTest {
 	 */
 	protected function getWarningList( $testFile = '' ) {
 		return [
-			12 => 1,
-			18 => 1,
-			52 => 1,
-			55 => 2,
+			31 => 1,
+			37 => 1,
+			86 => 1,
+			89 => 2,
 		];
 	}
 }

--- a/Apermo/Tests/Formatting/ConsistentAssignmentAlignmentUnitTest.php
+++ b/Apermo/Tests/Formatting/ConsistentAssignmentAlignmentUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the ConsistentAssignmentAlignment sniff.
+ * Tests the ConsistentAssignmentAlignment sniff.
  *
  * @package Apermo\Tests\Formatting
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\Formatting;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.Formatting.ConsistentAssignmentAlignment.
+ * Tests Apermo.Formatting.ConsistentAssignmentAlignment.
  */
 class ConsistentAssignmentAlignmentUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/Functions/ForbiddenNestedClosureUnitTest.php
+++ b/Apermo/Tests/Functions/ForbiddenNestedClosureUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the ForbiddenNestedClosure sniff.
+ * Tests the ForbiddenNestedClosure sniff.
  *
  * @package Apermo\Tests\Functions
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\Functions;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.Functions.ForbiddenNestedClosure.
+ * Tests Apermo.Functions.ForbiddenNestedClosure.
  */
 class ForbiddenNestedClosureUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/Hooks/RequireHookDocBlockUnitTest.inc
+++ b/Apermo/Tests/Hooks/RequireHookDocBlockUnitTest.inc
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable Apermo.Commenting.DocSummaryStyle -- Test markers (OK) aren't real docblocks.
 
 /**
  * Fires after a post is saved.

--- a/Apermo/Tests/Hooks/RequireHookDocBlockUnitTest.php
+++ b/Apermo/Tests/Hooks/RequireHookDocBlockUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the RequireHookDocBlock sniff.
+ * Tests the RequireHookDocBlock sniff.
  *
  * @package Apermo\Tests\Hooks
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\Hooks;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.Hooks.RequireHookDocBlock.
+ * Tests Apermo.Hooks.RequireHookDocBlock.
  */
 class RequireHookDocBlockUnitTest extends AbstractSniffUnitTest {
 
@@ -25,12 +25,12 @@ class RequireHookDocBlockUnitTest extends AbstractSniffUnitTest {
 	 */
 	protected function getErrorList( $testFile = '' ) {
 		return [
-			21 => 1,
-			25 => 1,
-			30 => 1,
-			37 => 1,
-			74 => 1,
-			84 => 2,
+			22 => 1,
+			26 => 1,
+			31 => 1,
+			38 => 1,
+			75 => 1,
+			85 => 2,
 		];
 	}
 

--- a/Apermo/Tests/Namespaces/GlobalFunctionQualificationUnitTest.php
+++ b/Apermo/Tests/Namespaces/GlobalFunctionQualificationUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the GlobalFunctionQualification sniff.
+ * Tests the GlobalFunctionQualification sniff.
  *
  * @package Apermo\Tests\Namespaces
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\Namespaces;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.Namespaces.GlobalFunctionQualification.
+ * Tests Apermo.Namespaces.GlobalFunctionQualification.
  */
 class GlobalFunctionQualificationUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/NamingConventions/MinimumVariableNameLengthUnitTest.php
+++ b/Apermo/Tests/NamingConventions/MinimumVariableNameLengthUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the MinimumVariableNameLength sniff.
+ * Tests the MinimumVariableNameLength sniff.
  *
  * @package Apermo\Tests\NamingConventions
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\NamingConventions;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.NamingConventions.MinimumVariableNameLength.
+ * Tests Apermo.NamingConventions.MinimumVariableNameLength.
  */
 class MinimumVariableNameLengthUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/Operators/DisallowPreIncrementDecrementUnitTest.php
+++ b/Apermo/Tests/Operators/DisallowPreIncrementDecrementUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the DisallowPreIncrementDecrement sniff.
+ * Tests the DisallowPreIncrementDecrement sniff.
  *
  * @package Apermo\Tests\Operators
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\Operators;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.Operators.DisallowPreIncrementDecrement.
+ * Tests Apermo.Operators.DisallowPreIncrementDecrement.
  */
 class DisallowPreIncrementDecrementUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/PHP/ExitUsageUnitTest.php
+++ b/Apermo/Tests/PHP/ExitUsageUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the ExitUsage sniff.
+ * Tests the ExitUsage sniff.
  *
  * @package Apermo\Tests\PHP
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\PHP;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.PHP.ExitUsage.
+ * Tests Apermo.PHP.ExitUsage.
  */
 class ExitUsageUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/PHP/ExplainCommentedOutCodeUnitTest.inc
+++ b/Apermo/Tests/PHP/ExplainCommentedOutCodeUnitTest.inc
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable Apermo.Commenting.DocSummaryStyle -- Summary keywords (Disabled, Kept, …) are the fixture under test.
 // Normal prose comment about the application logic.
 $a = 1;
 

--- a/Apermo/Tests/PHP/ExplainCommentedOutCodeUnitTest.php
+++ b/Apermo/Tests/PHP/ExplainCommentedOutCodeUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the ExplainCommentedOutCode sniff.
+ * Tests the ExplainCommentedOutCode sniff.
  *
  * @package Apermo\Tests\PHP
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\PHP;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.PHP.ExplainCommentedOutCode.
+ * Tests Apermo.PHP.ExplainCommentedOutCode.
  */
 class ExplainCommentedOutCodeUnitTest extends AbstractSniffUnitTest {
 
@@ -25,13 +25,13 @@ class ExplainCommentedOutCodeUnitTest extends AbstractSniffUnitTest {
 	 */
 	protected function getErrorList( $testFile = '' ) {
 		return [
-			29 => 1,
-			35 => 1,
-			38 => 1,
-			42 => 1,
-			46 => 1,
-			49 => 1,
-			58 => 1,
+			30 => 1,
+			36 => 1,
+			39 => 1,
+			43 => 1,
+			47 => 1,
+			50 => 1,
+			59 => 1,
 		];
 	}
 

--- a/Apermo/Tests/PHP/ForbiddenObjectCastUnitTest.php
+++ b/Apermo/Tests/PHP/ForbiddenObjectCastUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the ForbiddenObjectCast sniff.
+ * Tests the ForbiddenObjectCast sniff.
  *
  * @package Apermo\Tests\PHP
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\PHP;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.PHP.ForbiddenObjectCast.
+ * Tests Apermo.PHP.ForbiddenObjectCast.
  */
 class ForbiddenObjectCastUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/PHP/NoFilterSanitizeStringUnitTest.php
+++ b/Apermo/Tests/PHP/NoFilterSanitizeStringUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the NoFilterSanitizeString sniff.
+ * Tests the NoFilterSanitizeString sniff.
  *
  * @package Apermo\Tests\PHP
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\PHP;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.PHP.NoFilterSanitizeString.
+ * Tests Apermo.PHP.NoFilterSanitizeString.
  */
 class NoFilterSanitizeStringUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/PHP/PreferModernStringFunctionsUnitTest.php
+++ b/Apermo/Tests/PHP/PreferModernStringFunctionsUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the PreferModernStringFunctions sniff.
+ * Tests the PreferModernStringFunctions sniff.
  *
  * @package Apermo\Tests\PHP
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\PHP;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.PHP.PreferModernStringFunctions.
+ * Tests Apermo.PHP.PreferModernStringFunctions.
  */
 class PreferModernStringFunctionsUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/PHP/RequireAbsoluteIncludePathUnitTest.php
+++ b/Apermo/Tests/PHP/RequireAbsoluteIncludePathUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the RequireAbsoluteIncludePath sniff.
+ * Tests the RequireAbsoluteIncludePath sniff.
  *
  * @package Apermo\Tests\PHP
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\PHP;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.PHP.RequireAbsoluteIncludePath.
+ * Tests Apermo.PHP.RequireAbsoluteIncludePath.
  */
 class RequireAbsoluteIncludePathUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/PHP/RequireNotIncludeUnitTest.php
+++ b/Apermo/Tests/PHP/RequireNotIncludeUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the RequireNotInclude sniff.
+ * Tests the RequireNotInclude sniff.
  *
  * @package Apermo\Tests\PHP
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\PHP;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.PHP.RequireNotInclude.
+ * Tests Apermo.PHP.RequireNotInclude.
  */
 class RequireNotIncludeUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/PHP/SapiDependentFeaturesUnitTest.php
+++ b/Apermo/Tests/PHP/SapiDependentFeaturesUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the SapiDependentFeatures sniff.
+ * Tests the SapiDependentFeatures sniff.
  *
  * @package Apermo\Tests\PHP
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\PHP;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.PHP.SapiDependentFeatures.
+ * Tests Apermo.PHP.SapiDependentFeatures.
  */
 class SapiDependentFeaturesUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/WhiteSpace/MultipleEmptyLinesUnitTest.php
+++ b/Apermo/Tests/WhiteSpace/MultipleEmptyLinesUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the MultipleEmptyLines sniff.
+ * Tests the MultipleEmptyLines sniff.
  *
  * @package Apermo\Tests\WhiteSpace
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\WhiteSpace;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.WhiteSpace.MultipleEmptyLines.
+ * Tests Apermo.WhiteSpace.MultipleEmptyLines.
  */
 class MultipleEmptyLinesUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/WordPress/GlobalPostAccessUnitTest.php
+++ b/Apermo/Tests/WordPress/GlobalPostAccessUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the GlobalPostAccess sniff.
+ * Tests the GlobalPostAccess sniff.
  *
  * @package Apermo\Tests\WordPress
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\WordPress;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.WordPress.GlobalPostAccess.
+ * Tests Apermo.WordPress.GlobalPostAccess.
  */
 class GlobalPostAccessUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/WordPress/ImplicitPostFunctionUnitTest.php
+++ b/Apermo/Tests/WordPress/ImplicitPostFunctionUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the ImplicitPostFunction sniff.
+ * Tests the ImplicitPostFunction sniff.
  *
  * @package Apermo\Tests\WordPress
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\WordPress;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.WordPress.ImplicitPostFunction.
+ * Tests Apermo.WordPress.ImplicitPostFunction.
  */
 class ImplicitPostFunctionUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/WordPress/NoAdminAjaxUnitTest.php
+++ b/Apermo/Tests/WordPress/NoAdminAjaxUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the NoAdminAjax sniff.
+ * Tests the NoAdminAjax sniff.
  *
  * @package Apermo\Tests\WordPress
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\WordPress;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.WordPress.NoAdminAjax.
+ * Tests Apermo.WordPress.NoAdminAjax.
  */
 class NoAdminAjaxUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/WordPress/NoHardcodedTableNamesUnitTest.inc
+++ b/Apermo/Tests/WordPress/NoHardcodedTableNamesUnitTest.inc
@@ -50,3 +50,18 @@ $sql = "SELECT * FROM {$wpdb->prefix}custom_table WHERE id = 1";
 $sql = "SELECT * FROM {$wpdb->posts} WHERE id = 1";
 
 // phpcs:set Apermo.WordPress.NoHardcodedTableNames warnPrefix false
+
+// WARNING: hardcoded CREATE TABLE target.
+$sql = 'CREATE TABLE wp_custom (id INT PRIMARY KEY)';
+
+// WARNING: hardcoded DROP TABLE IF EXISTS target.
+$sql = 'DROP TABLE IF EXISTS wp_obsolete';
+
+// WARNING: hardcoded ALTER TABLE target.
+$sql = 'ALTER TABLE wp_users ADD COLUMN foo VARCHAR(50)';
+
+// OK: HTML <table> with CSS class — not SQL.
+$html = '<table class="wp-list-table widefat fixed striped">';
+
+// OK: HTML <table> with id — not SQL.
+$html = '<table id="users-table">';

--- a/Apermo/Tests/WordPress/NoHardcodedTableNamesUnitTest.inc
+++ b/Apermo/Tests/WordPress/NoHardcodedTableNamesUnitTest.inc
@@ -65,3 +65,15 @@ $html = '<table class="wp-list-table widefat fixed striped">';
 
 // OK: HTML <table> with id — not SQL.
 $html = '<table id="users-table">';
+
+// OK: English prose containing "from a" — not SQL.
+$msg = 'Lessons from a distributed team are instructive.';
+
+// OK: English prose containing "from the" — not SQL.
+$msg = 'Deactivate the plugin to hide these posts from the admin.';
+
+// OK: WP UI label starting with "Update" but no SET — not SQL.
+$label = 'Update Revision Tag';
+
+// OK: Prose mentioning "update" followed by noun — not SQL.
+$msg = 'Update the configuration before deploying.';

--- a/Apermo/Tests/WordPress/NoHardcodedTableNamesUnitTest.php
+++ b/Apermo/Tests/WordPress/NoHardcodedTableNamesUnitTest.php
@@ -44,6 +44,9 @@ class NoHardcodedTableNamesUnitTest extends AbstractSniffUnitTest {
 			21 => 1, // INTO custom_table.
 			24 => 1, // UPDATE wp_users.
 			47 => 1, // $wpdb->prefix interpolation (warnPrefix on).
+			55 => 1, // CREATE TABLE wp_custom.
+			58 => 1, // DROP TABLE IF EXISTS wp_obsolete.
+			61 => 1, // ALTER TABLE wp_users.
 		];
 	}
 }

--- a/Apermo/Tests/WordPress/NoHardcodedTableNamesUnitTest.php
+++ b/Apermo/Tests/WordPress/NoHardcodedTableNamesUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the NoHardcodedTableNames sniff.
+ * Tests the NoHardcodedTableNames sniff.
  *
  * @package Apermo\Tests\WordPress
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\WordPress;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.WordPress.NoHardcodedTableNames.
+ * Tests Apermo.WordPress.NoHardcodedTableNames.
  */
 class NoHardcodedTableNamesUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/WordPress/PreferWpdbIdentifierPlaceholderUnitTest.php
+++ b/Apermo/Tests/WordPress/PreferWpdbIdentifierPlaceholderUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the PreferWpdbIdentifierPlaceholder sniff.
+ * Tests the PreferWpdbIdentifierPlaceholder sniff.
  *
  * @package Apermo\Tests\WordPress
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\WordPress;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.WordPress.PreferWpdbIdentifierPlaceholder.
+ * Tests Apermo.WordPress.PreferWpdbIdentifierPlaceholder.
  */
 class PreferWpdbIdentifierPlaceholderUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/WordPress/RequireOptionAutoloadUnitTest.php
+++ b/Apermo/Tests/WordPress/RequireOptionAutoloadUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the RequireOptionAutoload sniff.
+ * Tests the RequireOptionAutoload sniff.
  *
  * @package Apermo\Tests\WordPress
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\WordPress;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.WordPress.RequireOptionAutoload.
+ * Tests Apermo.WordPress.RequireOptionAutoload.
  */
 class RequireOptionAutoloadUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/WordPress/RequireRestPermissionCallbackUnitTest.php
+++ b/Apermo/Tests/WordPress/RequireRestPermissionCallbackUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the RequireRestPermissionCallback sniff.
+ * Tests the RequireRestPermissionCallback sniff.
  *
  * @package Apermo\Tests\WordPress
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\WordPress;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.WordPress.RequireRestPermissionCallback.
+ * Tests Apermo.WordPress.RequireRestPermissionCallback.
  */
 class RequireRestPermissionCallbackUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/WordPress/RequireWpErrorHandlingUnitTest.inc
+++ b/Apermo/Tests/WordPress/RequireWpErrorHandlingUnitTest.inc
@@ -55,3 +55,12 @@ function array_assign( string $url ): array {
 
 // WARNING: top-level code without is_wp_error() check.
 $response = wp_remote_get( 'https://example.com' );
+
+// OK: wp_delete_post returns WP_Post|false|null, never WP_Error.
+$deleted = wp_delete_post( 123, true );
+
+// OK: wp_mail returns bool, never WP_Error.
+$sent = wp_mail( 'recipient@example.tld', 'subject', 'body' );
+
+// OK: wp_upload_bits returns array with 'error' string key, never WP_Error.
+$upload = wp_upload_bits( 'name.txt', null, 'bits' );

--- a/Apermo/Tests/WordPress/RequireWpErrorHandlingUnitTest.php
+++ b/Apermo/Tests/WordPress/RequireWpErrorHandlingUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the RequireWpErrorHandling sniff.
+ * Tests the RequireWpErrorHandling sniff.
  *
  * @package Apermo\Tests\WordPress
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\WordPress;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.WordPress.RequireWpErrorHandling.
+ * Tests Apermo.WordPress.RequireWpErrorHandling.
  */
 class RequireWpErrorHandlingUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/Tests/WordPress/SwitchToBlogRequiresRestoreUnitTest.php
+++ b/Apermo/Tests/WordPress/SwitchToBlogRequiresRestoreUnitTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Unit test for the SwitchToBlogRequiresRestore sniff.
+ * Tests the SwitchToBlogRequiresRestore sniff.
  *
  * @package Apermo\Tests\WordPress
  */
@@ -12,7 +12,7 @@ namespace Apermo\Tests\WordPress;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
- * Unit test for Apermo.WordPress.SwitchToBlogRequiresRestore.
+ * Tests Apermo.WordPress.SwitchToBlogRequiresRestore.
  */
 class SwitchToBlogRequiresRestoreUnitTest extends AbstractSniffUnitTest {
 

--- a/Apermo/polyfills.php
+++ b/Apermo/polyfills.php
@@ -7,7 +7,7 @@
 
 if ( ! function_exists( 'str_ends_with' ) ) {
 	/**
-	 * Polyfill for str_ends_with() (PHP 8.0+).
+	 * Backports str_ends_with() for PHP < 8.0.
 	 *
 	 * @param string $haystack The string to search in.
 	 * @param string $needle   The substring to search for.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `errorKeys`  10 → 20
   Consumers can still tighten via `<property>` overrides. Closes #97.
 
+### Fixed
+
+- `Apermo.WordPress.RequireWpErrorHandling.Unchecked` no longer
+  warns on `wp_delete_post()`, `wp_mail()`, and
+  `wp_upload_bits()` — none of these return `WP_Error`
+  (`WP_Post|false|null`, `bool`, and `array` respectively).
+  Closes #95.
+
 ## [2.7.0] - Unreleased
 
 ### Added
@@ -57,11 +65,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no longer fires in files without a namespace declaration.
   FQN like `\Throwable` or `\RuntimeException` are valid
   in no-namespace files where `use` statements are pointless.
-- `Apermo.WordPress.RequireWpErrorHandling.Unchecked` no longer
-  warns on `wp_delete_post()`, `wp_mail()`, and
-  `wp_upload_bits()` — none of these return `WP_Error`
-  (`WP_Post|false|null`, `bool`, and `array` respectively).
-  Closes #95.
 
 ## [2.6.4] - Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   known anti-patterns (`Allows you to`, `Lets you`, …), and a
   default `first-word-ends-in-s` check with a closer list for
   bare infinitives whose third-person form adds `-es`
-  (`Process`, `Fix`, `Access`, …). All warnings.
-  Closes #96.
+  (`Process`, `Fix`, `Access`, …). Property, constant, and bare
+  variable docblocks are skipped — their summaries are idiomatically
+  noun-form. All warnings. Closes #96.
 - `Apermo.DataStructures.ArrayComplexity.ComplexParameterKeys` and
   `ComplexParameterDepth` (error): flag custom function, method,
   and closure parameters whose default value or PHPStan/Psalm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no longer fires in files without a namespace declaration.
   FQN like `\Throwable` or `\RuntimeException` are valid
   in no-namespace files where `use` statements are pointless.
+- `Apermo.WordPress.RequireWpErrorHandling.Unchecked` no longer
+  warns on `wp_delete_post()`, `wp_mail()`, and
+  `wp_upload_bits()` — none of these return `WP_Error`
+  (`WP_Post|false|null`, `bool`, and `array` respectively).
+  Closes #95.
 
 ## [2.6.4] - Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `wp_upload_bits()` — none of these return `WP_Error`
   (`WP_Post|false|null`, `bool`, and `array` respectively).
   Closes #95.
+- `Apermo.WordPress.NoHardcodedTableNames.Found` no longer fires
+  on HTML `<table class="...">` elements. `TABLE` alone was too
+  ambiguous to act as a SQL anchor; it now only qualifies when
+  preceded by a DDL verb (`CREATE`, `DROP`, `ALTER`, `TRUNCATE`,
+  `RENAME`), with optional `IF [NOT] EXISTS`. Closes #101.
 
 ## [2.7.0] - Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.8.0] - Unreleased
+## [2.8.0] - 2026-04-19
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ambiguous to act as a SQL anchor; it now only qualifies when
   preceded by a DDL verb (`CREATE`, `DROP`, `ALTER`, `TRUNCATE`,
   `RENAME`), with optional `IF [NOT] EXISTS`. Closes #101.
+- `Apermo.WordPress.NoHardcodedTableNames.Found` no longer fires
+  on English prose or WP UI labels that happen to contain
+  FROM/UPDATE/etc. next to another word (e.g. `"lessons from a
+  team"`, `"Update Revision Tag"`). A string must now also
+  contain a secondary SQL marker (`SELECT`, `WHERE`, `SET`,
+  `VALUES`, `ORDER BY`, `GROUP BY`, `HAVING`, `LIMIT`, or a DDL
+  `TABLE` clause) before the table-name regex runs. Closes #102.
 
 ## [2.7.0] - Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `warnKeys`   5 → 10 (typical `WP_Query` arg sets land at 5–8)
     - `errorKeys`  10 → 20
   Consumers can still tighten via `<property>` overrides. Closes #97.
+- All shipped sniff and test source files now pass
+  `Apermo.Commenting.DocSummaryStyle` on the repo's own code
+  (third-person singular docblock summaries throughout).
+  Internal cleanup only — no user-visible behavior change.
+  Closes #100.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Apermo.Commenting.DocSummaryStyle` sniff: flags WordPress
+  docblock summaries that violate the third-person singular
+  style. Three layered checks: a configurable whitelist of
+  noun-lead openers (`Callback`, `Wrapper`, …), a blacklist of
+  known anti-patterns (`Allows you to`, `Lets you`, …), and a
+  default `first-word-ends-in-s` check with a closer list for
+  bare infinitives whose third-person form adds `-es`
+  (`Process`, `Fix`, `Access`, …). All warnings.
+  Closes #96.
 - `Apermo.DataStructures.ArrayComplexity.ComplexParameterKeys` and
   `ComplexParameterDepth` (error): flag custom function, method,
   and closure parameters whose default value or PHPStan/Psalm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.0] - Unreleased
+
+### Added
+
+- `Apermo.DataStructures.ArrayComplexity.ComplexParameterKeys` and
+  `ComplexParameterDepth` (error): flag custom function, method,
+  and closure parameters whose default value or PHPStan/Psalm
+  `@param array{...}` docblock shape exceeds
+  `parameterMaxKeys` (default 5) or `parameterMaxDepth` (default 2).
+  Unlike the existing literal-array checks (advisory warnings),
+  the signature author owns the shape and can refactor to a DTO.
+  Closes #98.
+
+### Changed
+
+- `Apermo.DataStructures.ArrayComplexity` default thresholds raised
+  so idiomatic WordPress usage (e.g. a `WP_Query` call with
+  `meta_query`, or a 7-key arg set) stays silent, while genuinely
+  monolithic shapes still surface:
+    - `warnDepth`  2 → 3 (`meta_query` is associative depth 3)
+    - `errorDepth` 3 → 5
+    - `warnKeys`   5 → 10 (typical `WP_Query` arg sets land at 5–8)
+    - `errorKeys`  10 → 20
+  Consumers can still tighten via `<property>` overrides. Closes #97.
+
 ## [2.7.0] - Unreleased
 
 ### Added
@@ -442,6 +467,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCompatibility checks targeting PHP 8.3+.
 - Empty `Apermo/Sniffs/` directory for future custom sniffs.
 
+[2.8.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.7.0...v2.8.0
 [2.7.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.4...v2.7.0
 [2.6.4]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.3...v2.6.4
 [2.6.3]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.2...v2.6.3

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ supports:
 - `register_rest_route()` must include `permission_callback`
 - `FILTER_SANITIZE_STRING` and related deprecated constants flagged
 - `add_option()`/`update_option()` must include explicit autoload parameter
+- Docblock summaries must be third-person singular per the WordPress documentation standard (`Displays…` not `Display…`, no `Allows you to…` / `Lets you…` anti-patterns)
 
 ### REST Permission Callback (`Apermo.WordPress.RequireRestPermissionCallback`)
 
@@ -442,43 +443,61 @@ Separate error codes (`IncludeFound`, `IncludeOnceFound`) allow independent conf
 
 Flags deeply nested or wide associative arrays that would benefit from typed objects (DTOs, value objects). Arrays with many string keys or deep nesting often indicate data structures that should be classes.
 
-Two independent checks, each with a warning and error threshold:
+Three independent checks. The first two apply to array literals (advisory, since literals often mirror external WordPress API shapes the caller does not own). The third applies to custom function, method, and closure parameters whose default value or PHPStan/Psalm `@param array{...}` shape is complex — those are errors, because the signature author owns the shape and can refactor to a DTO.
 
-| Check | Warning | Error | Default |
-|---|---|---|---|
-| Nesting depth | `TooDeep` | `TooDeepError` | warn > 2, error > 3 |
-| Key count | `TooManyKeys` | `TooManyKeysError` | warn > 5, error > 10 |
+| Check | Warning | Error | Default threshold | Applies to |
+|---|---|---|---|---|
+| Literal nesting depth | `TooDeep` | `TooDeepError` | warn > 3, error > 5 | Array literals |
+| Literal key count | `TooManyKeys` | `TooManyKeysError` | warn > 10, error > 20 | Array literals |
+| Parameter shape | — | `ComplexParameterKeys` / `ComplexParameterDepth` | error > 5 keys, error > 2 depth | Custom function/method/closure params |
 
-Only outermost arrays are checked — nested sub-arrays are not reported separately. Numeric arrays (without `=>`) are ignored entirely.
+Default thresholds for literals are tuned so idiomatic WordPress usage (a `WP_Query` call with `meta_query`, a 7-key arg set to `register_post_type`, etc.) stays silent. Genuinely monolithic shapes still surface.
+
+Only outermost literal arrays are checked — nested sub-arrays are not reported separately. Numeric arrays (without `=>`) are ignored entirely. The canonical fix for a literal `TooDeep` warning is to extract the complex sub-array into its own variable.
 
 ```php
-// Warning — 3 levels of associative nesting
+// Warning — 4 levels of associative nesting (literal)
 $order = [
     'customer' => [
         'address' => [
-            'city' => 'Berlin',
+            'details' => [
+                'city' => 'Berlin',
+            ],
         ],
     ],
 ];
 
-// Warning — 6 associative keys
+// Warning — 11 associative keys (literal)
 $user = [
-    'id'       => 1,
-    'name'     => 'John',
-    'email'    => 'john@example.com',
-    'role'     => 'admin',
-    'active'   => true,
-    'verified' => true,
+    'id' => 1, 'name' => 'John', 'email' => 'j@example.tld',
+    'role' => 'admin', 'active' => true, 'verified' => true,
+    'locale' => 'en', 'tz' => 'UTC', 'theme' => 'dark',
+    'mfa' => true, 'notifications' => 'email',
 ];
 
 // OK — numeric arrays are ignored
 $grid = [ [ 1, 2 ], [ 3, 4 ] ];
+
+// Error — parameter default with 6 top-level keys (ComplexParameterKeys)
+function make( array $opts = [
+    'a' => 1, 'b' => 2, 'c' => 3,
+    'd' => 4, 'e' => 5, 'f' => 6,
+] ): void {}
+
+// Error — @param shape exceeds parameterMaxDepth (ComplexParameterDepth)
+/**
+ * @param array{a: array{b: array{c: int}}} $opts
+ */
+function handle( array $opts ): void {}
+
+// Good — refactor to a DTO
+function handle( Options $opts ): void {}
 ```
 
 **Customization** via `phpcs.xml`:
 
 ```xml
-<!-- Adjust thresholds -->
+<!-- Adjust literal thresholds -->
 <rule ref="Apermo.DataStructures.ArrayComplexity">
     <properties>
         <property name="warnDepth" value="3"/>
@@ -488,11 +507,27 @@ $grid = [ [ 1, 2 ], [ 3, 4 ] ];
     </properties>
 </rule>
 
+<!-- Loosen or tighten the parameter-shape check -->
+<rule ref="Apermo.DataStructures.ArrayComplexity">
+    <properties>
+        <property name="parameterMaxKeys" value="8"/>
+        <property name="parameterMaxDepth" value="3"/>
+    </properties>
+</rule>
+
 <!-- Disable key count checks entirely -->
 <rule ref="Apermo.DataStructures.ArrayComplexity.TooManyKeys">
     <severity>0</severity>
 </rule>
 <rule ref="Apermo.DataStructures.ArrayComplexity.TooManyKeysError">
+    <severity>0</severity>
+</rule>
+
+<!-- Disable parameter-shape checks entirely -->
+<rule ref="Apermo.DataStructures.ArrayComplexity.ComplexParameterKeys">
+    <severity>0</severity>
+</rule>
+<rule ref="Apermo.DataStructures.ArrayComplexity.ComplexParameterDepth">
     <severity>0</severity>
 </rule>
 ```
@@ -651,6 +686,78 @@ apply_filters( 'my_title', $title );
     <severity>0</severity>
 </rule>
 <rule ref="Apermo.Hooks.RequireHookDocBlock.MissingReturn">
+    <severity>0</severity>
+</rule>
+```
+
+### Docblock Summary Style (`Apermo.Commenting.DocSummaryStyle`)
+
+Enforces third-person singular docblock summaries per the [WordPress PHP Documentation Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#1-summary). The rule of thumb: prepending "It" to the summary must read grammatically — `Displays the post title.` ("It displays…") passes; `Display the post title.` ("It display…") does not.
+
+Applies to function, method, class, interface, trait, and enum docblocks. Property, constant, and bare-variable docblocks are skipped — their summaries are idiomatically noun-form.
+
+Three layered checks, evaluated in order. First match wins.
+
+| Code | When |
+|---|---|
+| `AntiPattern` | First phrase matches a known bad opener (`Allows you to…`, `Lets you…`, `Used to…`, `This function/method/class…`) |
+| `BareInfinitive` | First word is a bare-infinitive verb whose third-person form adds `-es` (`Process`, `Pass`, `Fix`, `Focus`, `Access`, …) |
+| `NotThirdPerson` | First word does not end in `s` and is not on the whitelist |
+
+Whitelist (pass-through): `Callback`, `Wrapper`, `Helper`, `Utility`, `Alias`, `Shortcut`. Common noun-lead openers that WordPress style tolerates.
+
+All violations are warnings. No autofixer — rewriting verb forms reliably requires handling irregulars (`Do`→`Does`, `Have`→`Has`, `Go`→`Goes`) that a naive `+s` rule gets wrong.
+
+```php
+// Warning — "Display" doesn't end in s (NotThirdPerson)
+/** Display the date. */
+function render_date(): void {}
+
+// Warning — "Process" is a bare infinitive (BareInfinitive)
+/** Process the queue. */
+function handle_queue(): void {}
+
+// Warning — "Allows you to" is an anti-pattern (AntiPattern)
+/** Allows you to modify the post content. */
+
+// Good — third-person singular
+/** Displays the last modified date for a post. */
+function render_date(): void {}
+
+/** Filters the post content before rendering. */
+
+/** Fires after the plugin is initialized. */
+
+/** Callback for the save_post action. */  // whitelist passes
+
+// Skipped — property docblock (noun-form is idiomatic)
+class User {
+    /** The user's display name. */
+    public string $name = '';
+}
+```
+
+**Customization** via `phpcs.xml`:
+
+```xml
+<!-- Extend the whitelist of accepted noun-lead openers -->
+<rule ref="Apermo.Commenting.DocSummaryStyle">
+    <properties>
+        <property name="whitelist" type="array"
+                  value="Callback,Wrapper,Helper,Utility,Alias,Shortcut,Handler,Matcher"/>
+    </properties>
+</rule>
+
+<!-- Extend the anti-pattern list -->
+<rule ref="Apermo.Commenting.DocSummaryStyle">
+    <properties>
+        <property name="antiPatterns" type="array"
+                  value="Allows you to,Lets you,Used to,This function,This method,This class,Meant to"/>
+    </properties>
+</rule>
+
+<!-- Disable a specific error code -->
+<rule ref="Apermo.Commenting.DocSummaryStyle.AntiPattern">
     <severity>0</severity>
 </rule>
 ```

--- a/tests/Integration/Fixtures/DocSummaryStyle.inc
+++ b/tests/Integration/Fixtures/DocSummaryStyle.inc
@@ -60,11 +60,11 @@ class HasProperties {
 	public string $name = '';
 }
 
-// Constant docblock — noun-form summary skipped (line 65).
+// Constant docblock — noun-form summary skipped (line 64).
 /** Maximum retry attempts. */
 const MAX_RETRIES = 3;
 
-// Bare variable with noun-form docblock skipped (line 69).
+// Bare variable with noun-form docblock skipped (line 68).
 /** The current timestamp. */
 $now = 0;
 

--- a/tests/Integration/Fixtures/DocSummaryStyle.inc
+++ b/tests/Integration/Fixtures/DocSummaryStyle.inc
@@ -67,3 +67,23 @@ const MAX_RETRIES = 3;
 // Bare variable with noun-form docblock skipped (line 69).
 /** The current timestamp. */
 $now = 0;
+
+// @param tag first on a function (not a property) — skipped, no summary to check.
+/** @param string $x */
+function tag_first_fn( string $x ): void {}
+
+// Summary is only a backtick-quoted code reference — cleaned content is empty, skip.
+/** `wp_foo()` */
+function only_code_ref(): void {}
+
+// Summary contains no letters (only digits and punctuation) — skip.
+/** 123 — ??? */
+function no_letters(): void {}
+
+// Two back-to-back docblocks: first has no declaration before the next docblock opens.
+/** Runs first. */
+/** Displays the result. */
+function after_two_docs(): void {}
+
+// Trailing docblock at EOF with no attached declaration — walks off the end.
+/** Ends here. */

--- a/tests/Integration/Fixtures/DocSummaryStyle.inc
+++ b/tests/Integration/Fixtures/DocSummaryStyle.inc
@@ -53,3 +53,17 @@ function emp(): void {}
 // Backtick code ref stripped; third-person "handles" — OK (line 54).
 /** `wp_foo()` handles the request. */
 function code(): void {}
+
+// Property docblock — noun-form summary skipped (line 59).
+class HasProperties {
+	/** The user's display name. */
+	public string $name = '';
+}
+
+// Constant docblock — noun-form summary skipped (line 65).
+/** Maximum retry attempts. */
+const MAX_RETRIES = 3;
+
+// Bare variable with noun-form docblock skipped (line 69).
+/** The current timestamp. */
+$now = 0;

--- a/tests/Integration/Fixtures/DocSummaryStyle.inc
+++ b/tests/Integration/Fixtures/DocSummaryStyle.inc
@@ -1,0 +1,55 @@
+<?php
+// phpcs:disable WordPress,Squiz,PSR1,SlevomatCodingStandard,Generic,PSR2,PSR12,PEAR,Universal,Apermo
+// phpcs:enable Apermo.Commenting.DocSummaryStyle
+
+// Third-person singular — OK (line 6).
+/** Displays the post title. */
+function a(): void {}
+
+// Whitelist "Callback" — OK (line 10).
+/** Callback for the save_post action. */
+function b(): void {}
+
+// Irregular third-person "Is" — OK (line 14).
+/** Is true when the option is set. */
+function c(): void {}
+
+// AntiPattern "Allows you to" (line 18).
+/** Allows you to modify the post content. */
+function d(): void {}
+
+// AntiPattern "Lets you" (line 22).
+/** Lets you register custom post types. */
+function e(): void {}
+
+// BareInfinitive "Process" (line 26).
+/** Process the queue. */
+function f(): void {}
+
+// BareInfinitive "Fix" (line 30).
+/** Fix the offset. */
+function g(): void {}
+
+// NotThirdPerson "Display" (line 34).
+/** Display the date. */
+function h(): void {}
+
+// NotThirdPerson "Get" (line 38).
+/** Get the option value. */
+function i(): void {}
+
+// @param tag first — skip (line 42).
+/** @param string $x */
+$param = 1;
+
+// {@inheritDoc} — skip (line 46).
+/** {@inheritDoc} */
+function inh(): void {}
+
+// Empty — skip (line 50).
+/** */
+function emp(): void {}
+
+// Backtick code ref stripped; third-person "handles" — OK (line 54).
+/** `wp_foo()` handles the request. */
+function code(): void {}

--- a/tests/Integration/Fixtures/WpErrorHandling.inc
+++ b/tests/Integration/Fixtures/WpErrorHandling.inc
@@ -17,3 +17,18 @@ function good( string $u ): string {
 	}
 	return wp_remote_retrieve_body( $r );
 }
+
+// OK: wp_delete_post returns WP_Post|false|null, never WP_Error.
+function delete_ok( int $id ): void {
+	$r = wp_delete_post( $id, true );
+}
+
+// OK: wp_mail returns bool, never WP_Error.
+function mail_ok( string $body ): void {
+	$r = wp_mail( 'recipient@example.tld', 'subject', $body );
+}
+
+// OK: wp_upload_bits returns array with 'error' string key, never WP_Error.
+function upload_ok( string $name, string $bits ): void {
+	$r = wp_upload_bits( $name, null, $bits );
+}

--- a/tests/Integration/RulesetIntegrationTest.php
+++ b/tests/Integration/RulesetIntegrationTest.php
@@ -383,6 +383,9 @@ class RulesetIntegrationTest extends TestCase {
 		$file = $this->processFixture( 'WpErrorHandling.inc' );
 		$this->assertWarningOnLine( $file, 8, 'RequireWpErrorHandling', 'Unchecked wp_remote_get should warn.' );
 		$this->assertNoWarningsOnLine( $file, 14, 'Checked with is_wp_error should be allowed.' );
+		$this->assertNoWarningsOnLine( $file, 23, 'wp_delete_post returns WP_Post|false|null, never WP_Error.' );
+		$this->assertNoWarningsOnLine( $file, 28, 'wp_mail returns bool, never WP_Error.' );
+		$this->assertNoWarningsOnLine( $file, 33, 'wp_upload_bits returns an array, never WP_Error.' );
 	}
 
 	public function testPreferWpdbIdentifierPlaceholder(): void {

--- a/tests/Integration/RulesetIntegrationTest.php
+++ b/tests/Integration/RulesetIntegrationTest.php
@@ -472,6 +472,26 @@ class RulesetIntegrationTest extends TestCase {
 		$this->assertErrorOnLine( $file, 18, 'DisallowUseConst', 'use const should still be disallowed.' );
 	}
 
+	public function testDocSummaryStyle(): void {
+		$file = $this->processFixture( 'DocSummaryStyle.inc' );
+
+		$this->assertNoWarningsOnLine( $file, 6, 'Third-person singular "Displays" should pass.' );
+		$this->assertNoWarningsOnLine( $file, 10, 'Whitelisted "Callback" should pass.' );
+		$this->assertNoWarningsOnLine( $file, 14, 'Irregular third-person "Is" should pass.' );
+
+		$this->assertWarningOnLine( $file, 18, 'DocSummaryStyle.AntiPattern', '"Allows you to" should warn.' );
+		$this->assertWarningOnLine( $file, 22, 'DocSummaryStyle.AntiPattern', '"Lets you" should warn.' );
+		$this->assertWarningOnLine( $file, 26, 'DocSummaryStyle.BareInfinitive', 'Bare "Process" should warn.' );
+		$this->assertWarningOnLine( $file, 30, 'DocSummaryStyle.BareInfinitive', 'Bare "Fix" should warn.' );
+		$this->assertWarningOnLine( $file, 34, 'DocSummaryStyle.NotThirdPerson', 'Bare "Display" should warn.' );
+		$this->assertWarningOnLine( $file, 38, 'DocSummaryStyle.NotThirdPerson', 'Bare "Get" should warn.' );
+
+		$this->assertNoWarningsOnLine( $file, 42, 'Tag-first docblock should pass.' );
+		$this->assertNoWarningsOnLine( $file, 46, '{@inheritDoc} should pass.' );
+		$this->assertNoWarningsOnLine( $file, 50, 'Empty docblock should pass.' );
+		$this->assertNoWarningsOnLine( $file, 54, 'Backtick code ref then third-person verb should pass.' );
+	}
+
 	public function testDocCommentDescription(): void {
 		$file = $this->processFixture( 'DocCommentDescription.inc' );
 		$this->assertNoErrorsOnLine( $file, 6, '@see should satisfy the short description.' );

--- a/tests/Integration/RulesetIntegrationTest.php
+++ b/tests/Integration/RulesetIntegrationTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Integration tests for the Apermo PHPCS ruleset.
+ * Runs integration tests for the Apermo PHPCS ruleset.
  *
  * Verifies that ruleset.xml configuration (exclusions, severity overrides,
  * property settings) produces the expected errors and warnings when the
@@ -52,7 +52,7 @@ class RulesetIntegrationTest extends TestCase {
 	}
 
 	/**
-	 * Process a fixture file through the full Apermo ruleset.
+	 * Processes a fixture file through the full Apermo ruleset.
 	 *
 	 * @param string $fixture_name Fixture filename (e.g. "ArraySyntax.inc").
 	 *
@@ -69,7 +69,7 @@ class RulesetIntegrationTest extends TestCase {
 	}
 
 	/**
-	 * Assert that a specific line has at least one error from a sniff whose source contains the given substring.
+	 * Asserts that a specific line has at least one error from a sniff whose source contains the given substring.
 	 */
 	private function assertErrorOnLine( LocalFile $file, int $line, string $source_contains, string $message = '' ): void {
 		$errors = $file->getErrors();
@@ -81,7 +81,7 @@ class RulesetIntegrationTest extends TestCase {
 	}
 
 	/**
-	 * Assert that a specific line has at least one warning from a sniff whose source contains the given substring.
+	 * Asserts that a specific line has at least one warning from a sniff whose source contains the given substring.
 	 */
 	private function assertWarningOnLine( LocalFile $file, int $line, string $source_contains, string $message = '' ): void {
 		$warnings = $file->getWarnings();
@@ -93,7 +93,7 @@ class RulesetIntegrationTest extends TestCase {
 	}
 
 	/**
-	 * Assert that a specific line has no errors.
+	 * Asserts that a specific line has no errors.
 	 */
 	private function assertNoErrorsOnLine( LocalFile $file, int $line, string $message = '' ): void {
 		$errors = $file->getErrors();
@@ -101,7 +101,7 @@ class RulesetIntegrationTest extends TestCase {
 	}
 
 	/**
-	 * Assert that a specific line has no warnings.
+	 * Asserts that a specific line has no warnings.
 	 */
 	private function assertNoWarningsOnLine( LocalFile $file, int $line, string $message = '' ): void {
 		$warnings = $file->getWarnings();
@@ -109,7 +109,7 @@ class RulesetIntegrationTest extends TestCase {
 	}
 
 	/**
-	 * Collect all sniff source codes from a line's violations.
+	 * Collects all sniff source codes from a line's violations.
 	 *
 	 * @param array $columns Column-indexed array of violations.
 	 *
@@ -126,7 +126,7 @@ class RulesetIntegrationTest extends TestCase {
 	}
 
 	/**
-	 * Check if any source string contains the given substring.
+	 * Checks if any source string contains the given substring.
 	 */
 	private function sourceContains( array $sources, string $substring ): bool {
 		foreach ( $sources as $source ) {

--- a/tests/Integration/RulesetIntegrationTest.php
+++ b/tests/Integration/RulesetIntegrationTest.php
@@ -491,8 +491,8 @@ class RulesetIntegrationTest extends TestCase {
 		$this->assertNoWarningsOnLine( $file, 50, 'Empty docblock should pass.' );
 		$this->assertNoWarningsOnLine( $file, 54, 'Backtick code ref then third-person verb should pass.' );
 		$this->assertNoWarningsOnLine( $file, 59, 'Property docblock should be skipped.' );
-		$this->assertNoWarningsOnLine( $file, 65, 'Constant docblock should be skipped.' );
-		$this->assertNoWarningsOnLine( $file, 69, 'Bare variable docblock should be skipped.' );
+		$this->assertNoWarningsOnLine( $file, 64, 'Constant docblock should be skipped.' );
+		$this->assertNoWarningsOnLine( $file, 68, 'Bare variable docblock should be skipped.' );
 	}
 
 	public function testDocCommentDescription(): void {

--- a/tests/Integration/RulesetIntegrationTest.php
+++ b/tests/Integration/RulesetIntegrationTest.php
@@ -490,6 +490,9 @@ class RulesetIntegrationTest extends TestCase {
 		$this->assertNoWarningsOnLine( $file, 46, '{@inheritDoc} should pass.' );
 		$this->assertNoWarningsOnLine( $file, 50, 'Empty docblock should pass.' );
 		$this->assertNoWarningsOnLine( $file, 54, 'Backtick code ref then third-person verb should pass.' );
+		$this->assertNoWarningsOnLine( $file, 59, 'Property docblock should be skipped.' );
+		$this->assertNoWarningsOnLine( $file, 65, 'Constant docblock should be skipped.' );
+		$this->assertNoWarningsOnLine( $file, 69, 'Bare variable docblock should be skipped.' );
 	}
 
 	public function testDocCommentDescription(): void {


### PR DESCRIPTION
## Summary

Milestone 2.8.0. Seven issues shipped across 12 atomic commits. Each commit maps to one issue and can be reviewed independently.

### New sniff

- **`Apermo.Commenting.DocSummaryStyle`** (#96) — enforces WordPress third-person singular docblock summaries. Three layered checks: whitelist → anti-patterns → bare-infinitive closers → default `-s` check. Skips property/constant docblocks (noun-form summaries are idiomatic there).

### Tuning + extensions

- **`ArrayComplexity` thresholds raised** (#97) so idiomatic WordPress usage (`WP_Query` with `meta_query`, 7-key arg sets) stays silent. `warnDepth` 2→3, `errorDepth` 3→5, `warnKeys` 5→10, `errorKeys` 10→20.
- **`ArrayComplexity` parameter-signature check** (#98) — new error codes `ComplexParameterKeys` / `ComplexParameterDepth` fire on custom function/method/closure parameters whose default value or `@param array{...}` docblock shape is complex. Error (not warning) because the signature author owns the shape.

### False-positive fixes

- **`RequireWpErrorHandling`** (#95) — no longer warns on `wp_delete_post()`, `wp_mail()`, `wp_upload_bits()`. None return `WP_Error`.
- **`NoHardcodedTableNames` DDL scoping** (#101) — `TABLE` was too ambiguous and matched `<table class=...>` HTML. Now only qualifies after a DDL verb (`CREATE`/`DROP`/`ALTER`/`TRUNCATE`/`RENAME`), with optional `IF [NOT] EXISTS`.
- **`NoHardcodedTableNames` SQL-context gate** (#102) — broader fix for the same class of bug: `FROM`/`JOIN`/`INTO`/`UPDATE` fired on English prose (`'lessons from a team'`) and WP UI labels (`'Update Revision Tag'`). Now requires a secondary SQL marker (`SELECT`/`WHERE`/`SET`/`VALUES`/…) before the table-name regex runs.

### Housekeeping

- **Docblock cleanup** (#100) — rewrote ~160 docblock summaries across `Apermo/Sniffs/**` and `Apermo/Tests/**` into third-person singular to comply with the new `DocSummaryStyle` sniff.

## Commit map

| Commit     | Scope                                                       |
|------------|-------------------------------------------------------------|
| `b73efd4`  | refactor: extract `ArrayComplexity` counter (prep)          |
| `3606ff4`  | `ArrayComplexity` threshold bump — Closes #97               |
| `3ccd158`  | `ArrayComplexity` parameter check — Closes #98              |
| `45d4612`  | CHANGELOG 2.8.0 section                                     |
| `ac481be`  | `RequireWpErrorHandling` prune — Closes #95                 |
| `d467ed4`  | CHANGELOG move (follow-up to #95)                           |
| `3970fcd`  | `DocSummaryStyle` sniff — Closes #96                        |
| `5cbd3cb`  | `DocSummaryStyle` skip properties/consts (part of #96)      |
| `7d6a5a1`  | rewrite Sniff docblocks (part of #100)                      |
| `14ab55a`  | rewrite Test docblocks — Closes #100                        |
| `17a8ed7`  | `NoHardcodedTableNames` DDL scoping — Closes #101           |
| `1c2d0e1`  | `NoHardcodedTableNames` SQL-context gate — Closes #102      |

## Test plan

- [x] `composer test` — 76 tests, 229 assertions, all passing
- [x] PHPStan clean (pre-commit hook runs on every commit)
- [x] `vendor/bin/phpcs --standard=Apermo --sniffs=Apermo.Commenting.DocSummaryStyle Apermo/ tests/` reports only the 6 intentional warnings in `DocSummaryStyle.inc` (the sniff's own test fixture)
- [x] Smoke-tested `NoHardcodedTableNames` gate against real downstream strings (apermo/advanced-revisions PR #18)
- [ ] Final review that the bumped `ArrayComplexity` thresholds match expectations against a real WordPress plugin codebase

## Auto-close

Closes #95
Closes #96
Closes #97
Closes #98
Closes #100
Closes #101
Closes #102