### PR TITLE
feat(ruleset): require exit after wp_redirect

### DIFF
--- a/Apermo/ruleset.xml
+++ b/Apermo/ruleset.xml
@@ -137,6 +137,9 @@
 		<type>error</type>
 	</rule>
 
+	<!-- Require exit() after wp_redirect() / wp_safe_redirect() so script execution stops once headers are sent. -->
+	<rule ref="WordPressVIPMinimum.Security.ExitAfterRedirect"/>
+
 	<!-- Disallow Yoda conditions. -->
 	<rule ref="Generic.ControlStructures.DisallowYodaConditions"/>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `WordPressVIPMinimum.Security.ExitAfterRedirect` (error): flags
+  `wp_redirect()` and `wp_safe_redirect()` calls not followed by
+  `exit()`, preventing unintended output or side effects after
+  headers are sent — a known WordPress footgun, especially in
+  `admin_post_*` handlers. Pulled from `automattic/vipwpcs`
+  (cherry-picked; the full VIP ruleset is not included).
+  Closes #103.
+
 ## [2.8.0] - 2026-04-19
 
 ### Added
@@ -502,6 +514,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCompatibility checks targeting PHP 8.3+.
 - Empty `Apermo/Sniffs/` directory for future custom sniffs.
 
+[Unreleased]: https://github.com/apermo/apermo-coding-standards/compare/v2.8.0...HEAD
 [2.8.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.7.0...v2.8.0
 [2.7.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.4...v2.7.0
 [2.6.4]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.3...v2.6.4

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
 		"slevomat/coding-standard": "^8.0",
 		"yoast/yoastcs": "^3.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
-		"dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+		"automattic/vipwpcs": "^3.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^11.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95df949e895da167022186cf9b9e76e0",
+    "content-hash": "752dac55ad3f88534de3169b0136ef5b",
     "packages": [
         {
             "name": "automattic/vipwpcs",
@@ -2974,7 +2974,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.3"
+        "php": ">=7.4"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/tests/Integration/Fixtures/ExitAfterRedirect.inc
+++ b/tests/Integration/Fixtures/ExitAfterRedirect.inc
@@ -1,0 +1,25 @@
+<?php
+// phpcs:disable WordPress,Squiz,PSR1,SlevomatCodingStandard,Generic,PSR2,PEAR,Universal
+// phpcs:disable Apermo.PHP,Apermo.WhiteSpace,Apermo.Formatting,Apermo.Arrays,Apermo.Hooks
+// phpcs:disable Apermo.Functions,Apermo.DataStructures,Apermo.WordPress,Apermo.Commenting
+
+// Missing exit after wp_safe_redirect (line 7).
+wp_safe_redirect( 'https://example.tld/' );
+
+// Correct: exit() immediately follows (line 10).
+wp_safe_redirect( 'https://example.tld/' );
+exit();
+
+// Missing exit after wp_redirect (line 14).
+wp_redirect( 'https://example.tld/' );
+
+// Redirect inside conditional without exit (line 17).
+if ( isset( $_GET['go'] ) ) {
+	wp_safe_redirect( 'https://example.tld/' );
+}
+
+// Redirect inside conditional with exit — allowed (line 22).
+if ( isset( $_GET['go'] ) ) {
+	wp_safe_redirect( 'https://example.tld/' );
+	exit();
+}

--- a/tests/Integration/RulesetIntegrationTest.php
+++ b/tests/Integration/RulesetIntegrationTest.php
@@ -258,6 +258,15 @@ class RulesetIntegrationTest extends TestCase {
 		$this->assertNoErrorsOnLine( $file, 13, 'exit() should be allowed.' );
 	}
 
+	public function testExitAfterRedirect(): void {
+		$file = $this->processFixture( 'ExitAfterRedirect.inc' );
+		$this->assertErrorOnLine( $file, 7, 'ExitAfterRedirect.NoExit', 'wp_safe_redirect() without exit should be flagged.' );
+		$this->assertNoErrorsOnLine( $file, 10, 'wp_safe_redirect() followed by exit() should pass.' );
+		$this->assertErrorOnLine( $file, 14, 'ExitAfterRedirect.NoExit', 'wp_redirect() without exit should be flagged.' );
+		$this->assertErrorOnLine( $file, 18, 'ExitAfterRedirect', 'Redirect inside conditional without exit should be flagged.' );
+		$this->assertNoErrorsOnLine( $file, 23, 'Redirect inside conditional with exit() should pass.' );
+	}
+
 	public function testUnusedVariable(): void {
 		$file = $this->processFixture( 'UnusedVariable.inc' );
 		$this->assertErrorOnLine( $file, 9, 'UnusedVariable', 'Unused variable should be flagged.' );

--- a/tests/Integration/RulesetIntegrationTest.php
+++ b/tests/Integration/RulesetIntegrationTest.php
@@ -263,7 +263,7 @@ class RulesetIntegrationTest extends TestCase {
 		$this->assertErrorOnLine( $file, 7, 'ExitAfterRedirect.NoExit', 'wp_safe_redirect() without exit should be flagged.' );
 		$this->assertNoErrorsOnLine( $file, 10, 'wp_safe_redirect() followed by exit() should pass.' );
 		$this->assertErrorOnLine( $file, 14, 'ExitAfterRedirect.NoExit', 'wp_redirect() without exit should be flagged.' );
-		$this->assertErrorOnLine( $file, 18, 'ExitAfterRedirect', 'Redirect inside conditional without exit should be flagged.' );
+		$this->assertErrorOnLine( $file, 18, 'ExitAfterRedirect.NoExit', 'Redirect inside conditional without exit should be flagged.' );
 		$this->assertNoErrorsOnLine( $file, 23, 'Redirect inside conditional with exit() should pass.' );
 	}
 


### PR DESCRIPTION
## Summary

- Pulls in `automattic/vipwpcs` ^3.0 and cherry-picks
  `WordPressVIPMinimum.Security.ExitAfterRedirect` — flags
  `wp_redirect()` / `wp_safe_redirect()` calls not immediately
  followed by `exit()`. Prevents the known WordPress footgun where
  script execution continues after headers are sent.
- The full VIP ruleset is intentionally not enabled; only this one
  rule is imported.
- Integration fixture + test method cover: missing exit, exit
  present, wp_redirect variant, and the inside-conditional case.

Closes #103

## Test plan

- [x] `composer test` — full suite passes (77 tests, 237 assertions)
- [x] `composer analyse` — PHPStan clean
- [x] `vendor/bin/phpcs --standard=Apermo tests/Integration/Fixtures/ExitAfterRedirect.inc -s` — flags lines 7, 14, 18 with source `WordPressVIPMinimum.Security.ExitAfterRedirect.NoExit`
- [ ] CI green
- [ ] Smoke-test against `apermo/advanced-revisions` at PR #18 HEAD to confirm the originally reviewed handler is flagged