### PR TITLE
docs(changelog): use [2.9.0] - Unreleased heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.9.0] - Unreleased
 
 ### Added
 
@@ -514,7 +514,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCompatibility checks targeting PHP 8.3+.
 - Empty `Apermo/Sniffs/` directory for future custom sniffs.
 
-[Unreleased]: https://github.com/apermo/apermo-coding-standards/compare/v2.8.0...HEAD
+[2.9.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.8.0...HEAD
 [2.8.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.7.0...v2.8.0
 [2.7.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.4...v2.7.0
 [2.6.4]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.3...v2.6.4


### PR DESCRIPTION
## Summary

- Restores the project's convention of using `## [X.Y.Z] - Unreleased` during feature development (rather than the plain `## [Unreleased]` I used in #104).
- The release workflow then just swaps `Unreleased` for the release date — same one-line edit documented in `CLAUDE.md`.
- Compare-link identifier updated from `[Unreleased]` to `[2.9.0]` to match the heading.

Follows up on merged #104 where the heading was set wrong.

## Test plan

- [x] Diff reviewed — only the two identifier strings change
- [x] Changelog still parses as valid Markdown
- [ ] CI green