### PR TITLE
Release 3.0.0

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     stale:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-stale.yml@main
+        uses: apermo/reusable-workflows/.github/workflows/reusable-stale.yml@v0.6.2
         permissions:
             issues: write
             pull-requests: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,34 +1,12 @@
-name: 'Close stale issues and PRs'
+name: Stale
 
 on:
-  schedule:
-    - cron: '0 6 * * *'
-  workflow_dispatch:
-
-permissions:
-  issues: write
-  pull-requests: write
+    schedule:
+        - cron: '0 6 * * *'
 
 jobs:
-  stale:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/stale@v9
-        with:
-          days-before-stale: 30
-          days-before-close: 14
-
-          stale-issue-label: 'stale'
-          stale-pr-label: 'stale'
-
-          exempt-issue-labels: 'pinned,security,in-progress'
-          exempt-pr-labels: 'dependencies,security,in-progress'
-
-          stale-issue-message: >
-            This issue has been automatically marked as stale because it has not had
-            recent activity. It will be closed in 14 days if no further activity occurs.
-          stale-pr-message: >
-            This PR has been automatically marked as stale because it has not had
-            recent activity. It will be closed in 14 days if no further activity occurs.
-
-          operations-per-run: 30
+    stale:
+        uses: apermo/reusable-workflows/.github/workflows/reusable-stale.yml@main
+        permissions:
+            issues: write
+            pull-requests: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     stale:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-stale.yml@v0.6.2
+        uses: apermo/reusable-workflows/.github/workflows/reusable-stale.yml@main
         permissions:
             issues: write
             pull-requests: write

--- a/.github/workflows/validate-conventional-commits.yml
+++ b/.github/workflows/validate-conventional-commits.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
     validate:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-conventional-commits.yml@main
+        uses: apermo/reusable-workflows/.github/workflows/reusable-conventional-commits.yml@v0.6.2
         with:
             allowed-types: 'feat|fix|docs|style|refactor|test|chore|perf'

--- a/.github/workflows/validate-conventional-commits.yml
+++ b/.github/workflows/validate-conventional-commits.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
     validate:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-conventional-commits.yml@v0.6.2
+        uses: apermo/reusable-workflows/.github/workflows/reusable-conventional-commits.yml@main
         with:
             allowed-types: 'feat|fix|docs|style|refactor|test|chore|perf'

--- a/.github/workflows/validate-conventional-commits.yml
+++ b/.github/workflows/validate-conventional-commits.yml
@@ -1,91 +1,14 @@
 name: Validate Conventional Commits
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  push:
-    branches:
-      - main
+    pull_request:
+        types: [opened, synchronize, reopened]
+    push:
+        branches:
+            - main
 
 jobs:
-  validate-commits:
-    runs-on: ubuntu-latest
-    name: Check Commit Message Format
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+    validate:
+        uses: apermo/reusable-workflows/.github/workflows/reusable-conventional-commits.yml@main
         with:
-          fetch-depth: 0
-
-      - name: Get commit range
-        id: commit-range
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "base=${{ github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
-            echo "head=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
-          else
-            echo "base=${{ github.event.before }}" >> $GITHUB_OUTPUT
-            echo "head=${{ github.event.after }}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Validate commit messages
-        run: |
-          RED='\033[0;31m'
-          GREEN='\033[0;32m'
-          NC='\033[0m'
-
-          PATTERN="^(feat|fix|docs|style|refactor|test|chore|perf)(\(.+\))?: .{1,}$"
-
-          COMMITS=$(git log --format=%H ${{ steps.commit-range.outputs.base }}..${{ steps.commit-range.outputs.head }})
-
-          if [ -z "$COMMITS" ]; then
-            echo "No commits to validate"
-            exit 0
-          fi
-
-          INVALID_COMMITS=()
-
-          for COMMIT in $COMMITS; do
-            # Skip merge commits (e.g. GitHub "Merge pull request" button)
-            PARENTS=$(git rev-list --parents -n 1 $COMMIT | wc -w)
-            if [ "$PARENTS" -gt 2 ]; then
-              continue
-            fi
-
-            MSG=$(git log --format=%B -n 1 $COMMIT | head -n 1)
-
-            if ! echo "$MSG" | grep -qE "$PATTERN"; then
-              INVALID_COMMITS+=("$COMMIT: $MSG")
-            fi
-
-            LENGTH=${#MSG}
-            if [ $LENGTH -gt 72 ]; then
-              echo -e "${RED}Commit $COMMIT has subject line too long${NC}"
-              echo "   Length: $LENGTH characters (max: 72)"
-              echo "   Message: $MSG"
-              INVALID_COMMITS+=("$COMMIT: Subject too long")
-            fi
-          done
-
-          if [ ${#INVALID_COMMITS[@]} -gt 0 ]; then
-            echo -e "${RED}Invalid commit messages found:${NC}"
-            echo ""
-            for INVALID in "${INVALID_COMMITS[@]}"; do
-              echo "  $INVALID"
-            done
-            echo ""
-            echo "Commit messages must follow Conventional Commits format:"
-            echo "  <type>(<scope>): <subject>"
-            echo ""
-            echo "Valid types: feat, fix, docs, style, refactor, test, chore, perf"
-            echo "Subject: Max 72 characters (50 recommended)"
-            echo ""
-            echo "Examples:"
-            echo "  feat(sniff): add new ArrayComplexity sniff"
-            echo "  fix: resolve false positive in GlobalPostAccess"
-            echo "  docs: update README"
-            exit 1
-          fi
-
-          echo -e "${GREEN}All commit messages are valid${NC}"
+            allowed-types: 'feat|fix|docs|style|refactor|test|chore|perf'

--- a/Apermo/Sniffs/WordPress/ImplicitPostFunctionSniff.php
+++ b/Apermo/Sniffs/WordPress/ImplicitPostFunctionSniff.php
@@ -33,15 +33,21 @@ class ImplicitPostFunctionSniff extends AbstractPostContextSniff {
 	 * the appropriate argument.
 	 *
 	 * Structure: function_name => [
-	 *     'position' => int|null,  // 1-based param position, null = no post param
-	 *     'name'     => string,    // PHP parameter name (for named arg lookup)
+	 *     'position'      => int|null,  // 1-based param position, null = no post param
+	 *     'name'          => string,    // PHP parameter name (for named arg lookup)
+	 *     'allowsInteger' => bool,      // optional; suppress IntegerArgument warning
 	 * ]
 	 *
-	 * @var array<string, array{position: int|null, name: string}>
+	 * `allowsInteger` opts a function out of the IntegerArgument warning. Set
+	 * it for functions where the int form has distinct, intentional semantics
+	 * — e.g. `get_post( int )` forces a fresh DB fetch, while
+	 * `get_post( WP_Post )` returns the (possibly stale) object as-is.
+	 *
+	 * @var array<string, array{position: int|null, name: string, allowsInteger?: bool}>
 	 */
 	private const POST_FUNCTIONS = [
 		// Functions with a $post parameter.
-		'get_post'                          => [ 'position' => 1, 'name' => 'post' ],
+		'get_post'                          => [ 'position' => 1, 'name' => 'post', 'allowsInteger' => true ],
 		'get_post_format'                   => [ 'position' => 1, 'name' => 'post' ],
 		'get_the_title'                     => [ 'position' => 1, 'name' => 'post' ],
 		'get_the_excerpt'                   => [ 'position' => 1, 'name' => 'post' ],
@@ -181,7 +187,7 @@ class ImplicitPostFunctionSniff extends AbstractPostContextSniff {
 				'NullArgument',
 				[ $origName ]
 			);
-		} elseif ( $argType === 'integer' ) {
+		} elseif ( $argType === 'integer' && ( $config['allowsInteger'] ?? false ) === false ) {
 			$phpcsFile->addWarning(
 				'Function %s() called with integer post ID; pass WP_Post instead',
 				$stackPtr,

--- a/Apermo/Tests/WordPress/ImplicitPostFunctionUnitTest.inc
+++ b/Apermo/Tests/WordPress/ImplicitPostFunctionUnitTest.inc
@@ -19,7 +19,7 @@ function test_implicit() {
 
 	// Warning: IntegerArgument — literal int or ->ID.
 	get_the_title( 123 );
-	get_post( $post->ID );
+	get_the_title( $post->ID );
 	get_the_date( '', 42 );
 
 	// Error: NoPostParameter — function has no $post param.
@@ -73,3 +73,9 @@ $closure = function () {
 
 // Error: arrow function scope.
 $arrow = fn() => get_the_title();
+
+// OK: get_post( int ) / get_post( $var->ID ) — overload triggers fresh DB fetch.
+function refresh_post( $post ) {
+	$a = get_post( $post->ID );
+	$b = get_post( 123 );
+}

--- a/Apermo/ruleset.xml
+++ b/Apermo/ruleset.xml
@@ -34,10 +34,6 @@
 		<exclude name="Universal.Operators.DisallowStandalonePostIncrementDecrement"/>
 		<!-- Suggests pre-increment; conflicts with DisallowPreIncrementDecrement. -->
 		<exclude name="Squiz.Operators.IncrementDecrementUsage"/>
-		<!-- We allow short open tags. -->
-		<exclude name="Generic.PHP.DisallowShortOpenTag.EchoFound"/>
-		<!-- We allow short open tags. -->
-		<exclude name="Squiz.PHP.EmbeddedPhp.ShortOpenEchoNoSemicolon"/>
 
 		<!-- Filename rules are still open for discussion. -->
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mechanical: replace `<?= esc_html( $x ) ?>` with
   `<?php echo esc_html( $x ); ?>`. Closes #107.
 
+### Fixed
+
+- `Apermo.WordPress.ImplicitPostFunction.IntegerArgument` no
+  longer fires on `get_post( int )` or `get_post( $var->ID )`.
+  Unlike the other functions in `POST_FUNCTIONS`, `get_post()`
+  is overloaded: the int form forces a fresh DB fetch
+  (intentional after `wp_update_post()`), while passing a
+  `WP_Post` returns the (possibly stale) object as-is.
+  `get_post()` with no argument and `get_post( null )` still
+  error. Closes #110.
+
 ## [2.8.0] - 2026-04-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.0] - Unreleased
+## [3.0.0] - 2026-05-02
 
 ### Added
 
@@ -40,6 +40,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `WP_Post` returns the (possibly stale) object as-is.
   `get_post()` with no argument and `get_post( null )` still
   error. Closes #110.
+
+### CI
+
+- Migrate `stale.yml` to `apermo/reusable-workflows`
+  (`reusable-stale.yml`). Aligns with the rest of the
+  `apermo/*` namespace and centralizes future updates.
+  Closes #106.
+- Migrate `validate-conventional-commits.yml` to
+  `apermo/reusable-workflows`
+  (`reusable-conventional-commits.yml`). The shared workflow
+  supports the Conventional Commits `!` breaking-change
+  marker (`feat(scope)!: …`); the local copy did not.
+  Allowed-types kept narrow per this repo's style guide.
+  Closes #111.
 
 ## [2.8.0] - 2026-04-19
 
@@ -538,7 +552,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCompatibility checks targeting PHP 8.3+.
 - Empty `Apermo/Sniffs/` directory for future custom sniffs.
 
-[3.0.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.8.0...HEAD
+[3.0.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.8.0...v3.0.0
 [2.8.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.7.0...v2.8.0
 [2.7.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.4...v2.7.0
 [2.6.4]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.3...v2.6.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.9.0] - Unreleased
+## [3.0.0] - Unreleased
 
 ### Added
 
@@ -527,7 +527,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCompatibility checks targeting PHP 8.3+.
 - Empty `Apermo/Sniffs/` directory for future custom sniffs.
 
-[2.9.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.8.0...HEAD
+[3.0.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.8.0...HEAD
 [2.8.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.7.0...v2.8.0
 [2.7.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.4...v2.7.0
 [2.6.4]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.3...v2.6.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (cherry-picked; the full VIP ruleset is not included).
   Closes #103.
 
+### Removed
+
+- **BREAKING:** Short echo tags (`<?= … ?>`) are no longer
+  allowed. The ruleset previously excluded
+  `Generic.PHP.DisallowShortOpenTag.EchoFound` and
+  `Squiz.PHP.EmbeddedPhp.ShortOpenEchoNoSemicolon`; both
+  exclusions have been dropped so the WordPress defaults apply.
+  This brings local PHPCS in line with the WordPress.org Plugin
+  Check, which enforces `DisallowShortOpenTag.EchoFound` and is
+  not configurable from a consuming project. Migration is
+  mechanical: replace `<?= esc_html( $x ) ?>` with
+  `<?php echo esc_html( $x ); ?>`. Closes #107.
+
 ## [2.8.0] - 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ Severity depends on what was passed, not which function:
 |---|---|---|
 | `MissingArgument` | error | Post param exists but no argument provided |
 | `NullArgument` | error | Literal `null` passed as post argument |
-| `IntegerArgument` | warning | Literal int or `$var->ID` passed |
+| `IntegerArgument` | warning | Literal int or `$var->ID` passed (except `get_post()`, where the int overload triggers a fresh DB fetch) |
 | `NoPostParameter` | error | Function has no post param at all |
 
 ```php

--- a/tests/Integration/Fixtures/ImplicitPostFunction.inc
+++ b/tests/Integration/Fixtures/ImplicitPostFunction.inc
@@ -23,3 +23,9 @@ function test_the_post_thumbnail_missing() {
 function test_the_post_thumbnail_with_size() {
 	the_post_thumbnail( 'large' );
 }
+
+// get_post( $var->ID ) inside function scope is allowed: the int overload
+// forces a fresh DB fetch (line 30).
+function test_get_post_refresh( $post ) {
+	return get_post( $post->ID );
+}

--- a/tests/Integration/Fixtures/ShortEcho.inc
+++ b/tests/Integration/Fixtures/ShortEcho.inc
@@ -1,0 +1,11 @@
+<?php
+// phpcs:disable WordPress,PSR1,SlevomatCodingStandard,PSR2,PEAR,Universal
+// phpcs:disable Apermo.PHP,Apermo.WhiteSpace,Apermo.Formatting,Apermo.Arrays,Apermo.Hooks
+// phpcs:disable Apermo.Functions,Apermo.DataStructures,Apermo.WordPress,Apermo.Commenting
+
+$value = 'value';
+?>
+
+<p><?= esc_html( $value ) ?></p>
+
+<p><?= esc_html( $value ); ?></p>

--- a/tests/Integration/RulesetIntegrationTest.php
+++ b/tests/Integration/RulesetIntegrationTest.php
@@ -267,6 +267,13 @@ class RulesetIntegrationTest extends TestCase {
 		$this->assertNoErrorsOnLine( $file, 23, 'Redirect inside conditional with exit() should pass.' );
 	}
 
+	public function testShortEchoTagDisallowed(): void {
+		$file = $this->processFixture( 'ShortEcho.inc' );
+		$this->assertErrorOnLine( $file, 9, 'Generic.PHP.DisallowShortOpenTag.EchoFound', '<?= without semicolon should be flagged as short echo tag.' );
+		$this->assertErrorOnLine( $file, 9, 'Squiz.PHP.EmbeddedPhp.ShortOpenEchoNoSemicolon', '<?= without trailing semicolon should be flagged.' );
+		$this->assertErrorOnLine( $file, 11, 'Generic.PHP.DisallowShortOpenTag.EchoFound', '<?= with semicolon should still be flagged as short echo tag.' );
+	}
+
 	public function testUnusedVariable(): void {
 		$file = $this->processFixture( 'UnusedVariable.inc' );
 		$this->assertErrorOnLine( $file, 9, 'UnusedVariable', 'Unused variable should be flagged.' );

--- a/tests/Integration/RulesetIntegrationTest.php
+++ b/tests/Integration/RulesetIntegrationTest.php
@@ -470,6 +470,8 @@ class RulesetIntegrationTest extends TestCase {
 		$this->assertNoErrorsOnLine( $file, 14, 'get_post_format() with post should be allowed.' );
 		$this->assertErrorOnLine( $file, 19, 'NoPostParameter', 'the_post_thumbnail() without argument should be flagged.' );
 		$this->assertErrorOnLine( $file, 24, 'NoPostParameter', 'the_post_thumbnail() with size should still be flagged.' );
+		$this->assertNoErrorsOnLine( $file, 30, 'get_post( $var->ID ) should be allowed (fresh-fetch overload).' );
+		$this->assertNoWarningsOnLine( $file, 30, 'get_post( $var->ID ) should not warn (fresh-fetch overload).' );
 	}
 
 	public function testBooleanOperators(): void {


### PR DESCRIPTION
## Summary

3.0.0 release bundle. Includes one breaking change, one new sniff (rolled forward from the previously-pending 2.9.0), one false-positive fix, and two CI workflow migrations.

### Breaking

- **Drop short-echo allowance** — Drop ruleset excludes for `Generic.PHP.DisallowShortOpenTag.EchoFound` and `Squiz.PHP.EmbeddedPhp.ShortOpenEchoNoSemicolon`. Short echo tags (`<?= … ?>`) now error, matching the WordPress.org Plugin Check (which is non-configurable from consuming projects). Closes #107.

### Added

- **`WordPressVIPMinimum.Security.ExitAfterRedirect`** — flags `wp_redirect()` / `wp_safe_redirect()` calls not followed by `exit()`. Cherry-picked from `automattic/vipwpcs`. Closes #103.

### Fixed

- **`Apermo.WordPress.ImplicitPostFunction.IntegerArgument` no longer fires on `get_post( int )` / `get_post( $var->ID )`** — `get_post()` is overloaded; the int form forces a fresh DB fetch (intentional after `wp_update_post()`), while passing `WP_Post` returns the (possibly stale) object as-is. `get_post()` with no argument and `get_post( null )` still error. Closes #110.

### CI

- **Migrate `stale.yml` to `apermo/reusable-workflows`** — replace standalone `actions/stale@v9` invocation with a call to the shared reusable workflow. Closes #106.
- **Migrate `validate-conventional-commits.yml` to `apermo/reusable-workflows`** — the local regex never supported the Conventional Commits `!` breaking-change marker; the reusable workflow does. Allowed-types kept narrow per this repo's style guide. Closes #111.

## Migration

Replace short echo tags mechanically:

```php
<?= esc_html( $x ) ?>      →  <?php echo esc_html( $x ); ?>
<?= esc_attr( $y ) ?>      →  <?php echo esc_attr( $y ); ?>
```

## Test plan

- [x] `composer test` (PHPStan + PHPUnit) green locally — 78/78 passing
- [x] New `testShortEchoTagDisallowed` integration test covers both error codes on a `<?= … ?>` fixture
- [x] `testImplicitPostFunction` extended with a no-warning assertion for `get_post( $var->ID )`
- [x] Manual phpcs probe: `get_post( $post->ID )` silent; `get_post()`, `get_post( null )`, `get_the_title( $post->ID )` still flagged as before
- [ ] CI green
- [ ] Set release date in CHANGELOG before merge: `## [3.0.0] - YYYY-MM-DD`