### PR TITLE
ci(stale): migrate to apermo reusable workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,34 +1,12 @@
-name: 'Close stale issues and PRs'
+name: Stale
 
 on:
-  schedule:
-    - cron: '0 6 * * *'
-  workflow_dispatch:
-
-permissions:
-  issues: write
-  pull-requests: write
+    schedule:
+        - cron: '0 6 * * *'
 
 jobs:
-  stale:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/stale@v9
-        with:
-          days-before-stale: 30
-          days-before-close: 14
-
-          stale-issue-label: 'stale'
-          stale-pr-label: 'stale'
-
-          exempt-issue-labels: 'pinned,security,in-progress'
-          exempt-pr-labels: 'dependencies,security,in-progress'
-
-          stale-issue-message: >
-            This issue has been automatically marked as stale because it has not had
-            recent activity. It will be closed in 14 days if no further activity occurs.
-          stale-pr-message: >
-            This PR has been automatically marked as stale because it has not had
-            recent activity. It will be closed in 14 days if no further activity occurs.
-
-          operations-per-run: 30
+    stale:
+        uses: apermo/reusable-workflows/.github/workflows/reusable-stale.yml@main
+        permissions:
+            issues: write
+            pull-requests: write


### PR DESCRIPTION
## Summary

- Replace standalone `actions/stale@v9` invocation in `.github/workflows/stale.yml` with a call to `apermo/reusable-workflows/.github/workflows/reusable-stale.yml@main`.
- Aligns this repo with the rest of the `apermo/*` namespace (15+ repos already use the reusable workflow) and centralizes future updates.
- Defaults from the reusable workflow: issues 30/14, PRs 60/21 (longer PR window better fits in-flight work). Per-repo overrides remain available via `days-before-issue-stale` etc. inputs if needed later.

Closes #106

## Test plan

- [ ] Workflow run on schedule (or via `workflow_dispatch` on the reusable workflow) processes issues/PRs without errors
- [ ] CI green on this PR