### PR TITLE
chore(deps): adopt WPCS 3.4.0 and tighten floors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.1.0] - Unreleased
 
 ### Changed
+
+- Require `wp-coding-standards/wpcs` `^3.4` (was `^3.0`) and
+  `squizlabs/php_codesniffer` `^3.13.5` (was `^3.10`) to adopt WPCS
+  3.4.0. Brings bug fixes (`PreparedSQL`, `EscapeOutput`,
+  `AlternativeFunctions`, `CronInterval`), WP 7.0.0 deprecation and
+  pluggable-function recognition, a stricter `NoSilencedErrors` (no
+  longer allows `@parse_url()`), and a new default `minimum_wp_version`
+  of 6.7. No ruleset changes.
+
+### CI
 
 - Bump GitHub Actions off the deprecated Node 20 runtime: `actions/cache`
   v4→v5, `actions/checkout` v4→v5, `actions/github-script` v7→v8. GitHub
@@ -560,6 +570,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCompatibility checks targeting PHP 8.3+.
 - Empty `Apermo/Sniffs/` directory for future custom sniffs.
 
+[3.1.0]: https://github.com/apermo/apermo-coding-standards/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.8.0...v3.0.0
 [2.8.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.7.0...v2.8.0
 [2.7.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.6.4...v2.7.0

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
 	"keywords": ["phpcs", "wordpress", "coding-standards", "static-analysis"],
 	"require": {
 		"php": ">=7.4",
-		"squizlabs/php_codesniffer": "^3.10",
-		"wp-coding-standards/wpcs": "^3.0",
+		"squizlabs/php_codesniffer": "^3.13.5",
+		"wp-coding-standards/wpcs": "^3.4",
 		"slevomat/coding-standard": "^8.0",
 		"yoast/yoastcs": "^3.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "752dac55ad3f88534de3169b0136ef5b",
+    "content-hash": "ca7657512d85349c686903a9e71d0e06",
     "packages": [
         {
             "name": "automattic/vipwpcs",
@@ -955,16 +955,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.3.0",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6"
+                "reference": "469c18ceab4d642b15bad4c65ebf3b307bfd55ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
-                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/469c18ceab4d642b15bad4c65ebf3b307bfd55ab",
+                "reference": "469c18ceab4d642b15bad4c65ebf3b307bfd55ab",
                 "shasum": ""
             },
             "require": {
@@ -974,8 +974,8 @@
                 "ext-xmlreader": "*",
                 "php": ">=7.2",
                 "phpcsstandards/phpcsextra": "^1.5.0",
-                "phpcsstandards/phpcsutils": "^1.1.0",
-                "squizlabs/php_codesniffer": "^3.13.4"
+                "phpcsstandards/phpcsutils": "^1.2.2",
+                "squizlabs/php_codesniffer": "^3.13.5"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -1017,7 +1017,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-11-25T12:08:04+00:00"
+            "time": "2026-07-16T13:05:29+00:00"
         },
         {
             "name": "yoast/yoastcs",


### PR DESCRIPTION
## Summary

Adopts WordPress Coding Standards 3.4.0 (released 2026-07-16). After reviewing the full 3.4.0 changelog, this is a **dependency-only** change — none of the sniffs touched by 3.4.0 are referenced in `Apermo/ruleset.xml` or exercised by the integration tests, so **no ruleset changes** are needed.

## Changes

- **`composer.json`** — tighten floors to match 3.4.0's real requirements:
  - `wp-coding-standards/wpcs`: `^3.0` → `^3.4`
  - `squizlabs/php_codesniffer`: `^3.10` → `^3.13.5`
- **`composer.lock`** — wpcs 3.3.0 → 3.4.0 (phpcs 3.13.5 / phpcsutils 1.2.2 already satisfied)
- **`CHANGELOG.md`** — new `## [3.1.0] - Unreleased` entry

## What 3.4.0 brings (adopted automatically, no config)

- Bug fixes: `PreparedSQL`/`PreparedSQLPlaceholders`, `EscapeOutput`, `AlternativeFunctions`, `CronInterval`
- WP 7.0.0 deprecation & pluggable-function recognition (`PrefixAllGlobals`, `ClassNameCase`, `DeprecatedFunctions`)
- Stricter `NoSilencedErrors` — no longer permits `@parse_url()`
- Improved error messages; end-user sniff documentation

## Decisions

- **`minimum_wp_version` default → 6.7:** silent adoption — left unset, consumers inherit the new default.
- **New `allow_single_item_single_line_explicit_key_arrays` property:** omitted — we never configured `ArrayDeclarationSpacing`.

## Verification

`composer test` (PHPStan + full unit + integration suite): **78 tests, 245 assertions, all green**. `Apermo` standard still registers via `phpcs -i`.