### PR TITLE
chore(deps): require WPCS 3.4.1 security release (3.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.0] - Unreleased
 
+### Security
+
+- Require `wp-coding-standards/wpcs` `^3.4.1` to fix
+  [GHSA-3pwp-g2mj-5p3v](https://github.com/WordPress/WordPress-Coding-Standards/security/advisories/GHSA-3pwp-g2mj-5p3v)
+  (CVSS 8.6, high). The `WordPress.WP.EnqueuedResourceParameters`
+  sniff reconstructed function arguments and passed them to
+  `eval()`, so scanning untrusted PHP — CI on pull requests,
+  third-party code review — could execute arbitrary commands on
+  the scanning host. WPCS 0.14.1 through 3.4.0 were affected via
+  the `WordPress` and `WordPress-Extra` rulesets; `Apermo`
+  references `WordPress`, so it was in the affected set. The floor
+  is raised rather than only the lockfile refreshed, so consuming
+  projects cannot resolve back to a vulnerable version.
+
 ### Changed
 
-- Require `wp-coding-standards/wpcs` `^3.4` (was `^3.0`) and
+- Require `wp-coding-standards/wpcs` `^3.4.1` (was `^3.0`) and
   `squizlabs/php_codesniffer` `^3.13.5` (was `^3.10`) to adopt WPCS
-  3.4.0. Brings bug fixes (`PreparedSQL`, `EscapeOutput`,
+  3.4.0/3.4.1. Brings bug fixes (`PreparedSQL`, `EscapeOutput`,
   `AlternativeFunctions`, `CronInterval`), WP 7.0.0 deprecation and
   pluggable-function recognition, a stricter `NoSilencedErrors` (no
   longer allows `@parse_url()`), and a new default `minimum_wp_version`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.0] - Unreleased
+## [3.1.1] - 2026-07-29
 
 ### Security
 
-- Require `wp-coding-standards/wpcs` `^3.4.1` to fix
+- Require `wp-coding-standards/wpcs` `^3.4.1` (was `^3.4`) to fix
   [GHSA-3pwp-g2mj-5p3v](https://github.com/WordPress/WordPress-Coding-Standards/security/advisories/GHSA-3pwp-g2mj-5p3v)
   (CVSS 8.6, high). The `WordPress.WP.EnqueuedResourceParameters`
   sniff reconstructed function arguments and passed them to
@@ -19,13 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the `WordPress` and `WordPress-Extra` rulesets; `Apermo`
   references `WordPress`, so it was in the affected set. The floor
   is raised rather than only the lockfile refreshed, so consuming
-  projects cannot resolve back to a vulnerable version.
+  projects cannot resolve back to a vulnerable version. No ruleset
+  changes.
+
+## [3.1.0] - 2026-07-17
 
 ### Changed
 
-- Require `wp-coding-standards/wpcs` `^3.4.1` (was `^3.0`) and
+- Require `wp-coding-standards/wpcs` `^3.4` (was `^3.0`) and
   `squizlabs/php_codesniffer` `^3.13.5` (was `^3.10`) to adopt WPCS
-  3.4.0/3.4.1. Brings bug fixes (`PreparedSQL`, `EscapeOutput`,
+  3.4.0. Brings bug fixes (`PreparedSQL`, `EscapeOutput`,
   `AlternativeFunctions`, `CronInterval`), WP 7.0.0 deprecation and
   pluggable-function recognition, a stricter `NoSilencedErrors` (no
   longer allows `@parse_url()`), and a new default `minimum_wp_version`
@@ -584,6 +587,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCompatibility checks targeting PHP 8.3+.
 - Empty `Apermo/Sniffs/` directory for future custom sniffs.
 
+[3.1.1]: https://github.com/apermo/apermo-coding-standards/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/apermo/apermo-coding-standards/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.8.0...v3.0.0
 [2.8.0]: https://github.com/apermo/apermo-coding-standards/compare/v2.7.0...v2.8.0

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	"require": {
 		"php": ">=7.4",
 		"squizlabs/php_codesniffer": "^3.13.5",
-		"wp-coding-standards/wpcs": "^3.4",
+		"wp-coding-standards/wpcs": "^3.4.1",
 		"slevomat/coding-standard": "^8.0",
 		"yoast/yoastcs": "^3.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,36 +4,36 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca7657512d85349c686903a9e71d0e06",
+    "content-hash": "7901b7a823af00a288fd35235e78c205",
     "packages": [
         {
             "name": "automattic/vipwpcs",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "2b1d206d81b74ed999023cffd924f862ff2753c8"
+                "reference": "9c47cd036754e0e5f354a9914568f052043c3f30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/2b1d206d81b74ed999023cffd924f862ff2753c8",
-                "reference": "2b1d206d81b74ed999023cffd924f862ff2753c8",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/9c47cd036754e0e5f354a9914568f052043c3f30",
+                "reference": "9c47cd036754e0e5f354a9914568f052043c3f30",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.2.1",
-                "phpcsstandards/phpcsutils": "^1.0.11",
-                "sirbrillig/phpcs-variable-analysis": "^2.11.18",
-                "squizlabs/php_codesniffer": "^3.9.2",
-                "wp-coding-standards/wpcs": "^3.1.0"
+                "php": ">=7.4",
+                "phpcsstandards/phpcsextra": "^1.5.1",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "sirbrillig/phpcs-variable-analysis": "^2.13.0",
+                "squizlabs/php_codesniffer": "^3.13.5",
+                "wp-coding-standards/wpcs": "^3.4.1"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9",
-                "phpcsstandards/phpcsdevtools": "^1.0",
-                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+                "phpcsstandards/phpcsdevtools": "^1.2.3",
+                "phpunit/phpunit": "^9"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -58,20 +58,20 @@
                 "source": "https://github.com/Automattic/VIP-Coding-Standards",
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2024-05-10T20:31:09+00:00"
+            "time": "2026-07-27T14:33:48+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
@@ -154,7 +154,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-11T04:32:07+00:00"
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "php-parallel-lint/php-console-color",
@@ -533,21 +533,21 @@
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "b598aa890815b8df16363271b659d73280129101"
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/b598aa890815b8df16363271b659d73280129101",
-                "reference": "b598aa890815b8df16363271b659d73280129101",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/39467533fdb742446d68c1d10ac33d625ee0311c",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.2.0",
+                "phpcsstandards/phpcsutils": "^1.2.3",
                 "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
             },
             "require-dev": {
@@ -611,20 +611,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-12T23:06:57+00:00"
+            "time": "2026-07-27T11:13:17+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
                 "shasum": ""
             },
             "require": {
@@ -704,7 +704,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-12-08T14:27:58+00:00"
+            "time": "2026-07-27T10:28:41+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -955,16 +955,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.4.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "469c18ceab4d642b15bad4c65ebf3b307bfd55ab"
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/469c18ceab4d642b15bad4c65ebf3b307bfd55ab",
-                "reference": "469c18ceab4d642b15bad4c65ebf3b307bfd55ab",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/ec2ff942335f33683a5957a85d138753876a05cf",
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf",
                 "shasum": ""
             },
             "require": {
@@ -973,8 +973,8 @@
                 "ext-tokenizer": "*",
                 "ext-xmlreader": "*",
                 "php": ">=7.2",
-                "phpcsstandards/phpcsextra": "^1.5.0",
-                "phpcsstandards/phpcsutils": "^1.2.2",
+                "phpcsstandards/phpcsextra": "^1.5.1",
+                "phpcsstandards/phpcsutils": "^1.2.3",
                 "squizlabs/php_codesniffer": "^3.13.5"
             },
             "require-dev": {
@@ -1017,7 +1017,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-07-16T13:05:29+00:00"
+            "time": "2026-07-27T11:53:23+00:00"
         },
         {
             "name": "yoast/yoastcs",
@@ -1144,20 +1144,19 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.7.0",
+            "version": "v5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": ">=7.4"
@@ -1196,9 +1195,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
             },
-            "time": "2025-12-06T11:56:16+00:00"
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1771,24 +1770,24 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.53",
+            "version": "11.5.56",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a997a653a82845f1240d73ee73a8a4e97e4b0607"
+                "reference": "5f83edffa6967c3db468d48a695ec7bcb02e9256"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a997a653a82845f1240d73ee73a8a4e97e4b0607",
-                "reference": "a997a653a82845f1240d73ee73a8a4e97e4b0607",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5f83edffa6967c3db468d48a695ec7bcb02e9256",
+                "reference": "5f83edffa6967c3db468d48a695ec7bcb02e9256",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
@@ -1853,31 +1852,15 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.53"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.56"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2026-02-10T12:28:25+00:00"
+            "time": "2026-07-06T14:52:39+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
## Summary

Raises the `wp-coding-standards/wpcs` floor to `^3.4.1` to pick up the fix for
[GHSA-3pwp-g2mj-5p3v](https://github.com/WordPress/WordPress-Coding-Standards/security/advisories/GHSA-3pwp-g2mj-5p3v)
(CVSS 8.6, high).

The `WordPress.WP.EnqueuedResourceParameters` sniff reconstructed function arguments and passed them to `eval()` in its
`is_falsy()` method. Scanning untrusted PHP — CI on pull requests, third-party code review — could execute arbitrary
commands on the scanning host. WPCS 0.14.1 through 3.4.0 are affected via the `WordPress` and `WordPress-Extra`
rulesets. `Apermo/ruleset.xml` references `WordPress`, so this package was in the affected set.

The floor is raised rather than only the lockfile refreshed, so consuming projects cannot resolve back to a vulnerable
version.

## Dependency changes

| Package | From | To | Note |
| --- | --- | --- | --- |
| `wp-coding-standards/wpcs` | `^3.4` / 3.4.0 | `^3.4.1` / 3.4.1 | Constraint + lock |
| `phpcsstandards/phpcsutils` | 1.2.2 | 1.2.3 | Transitive minimum of WPCS 3.4.1 |
| `phpcsstandards/phpcsextra` | 1.5.0 | 1.5.1 | Transitive minimum of WPCS 3.4.1 |
| `automattic/vipwpcs` | 3.0.1 | 3.1.0 | Lock only |
| `dealerdirect/phpcodesniffer-composer-installer` | 1.2.0 | 1.2.1 | Lock only |
| `phpunit/phpunit` | 11.5.53 | 11.5.56 | Lock only, dev |

No ruleset changes.

## Held back deliberately

- **`slevomat/coding-standard`** 8.22.1 → 8.31.0 — every release from 8.23.0 on requires `squizlabs/php_codesniffer ^4`.
  WPCS 3.4.1 still requires `^3.13.5`, so 8.22.1 is the ceiling until WPCS supports PHPCS 4.
- **`yoast/yoastcs`** 3.3.0 → 3.4.2 — 3.4.x requires `phpcompatibility/phpcompatibility-wp ^3.0.0@alpha`. 3.3.0 is the
  last release on the stable 2.x line.
- **`squizlabs/php_codesniffer`** 3.13.5 → 4.0.1 — blocked by WPCS, as above.
- **`phpstan/phpstan`** 2.1.39 → 2.2.6 — 2.2.6 reports `identical.alwaysFalse` on
  `Apermo/Sniffs/PHP/ExplainCommentedOutCodeSniff.php:299`. That line is the division-by-zero guard for
  `$num_code / $num_tokens` on line 335, and PHPStan can only call it dead by reasoning it cannot actually verify (its
  own hint notes the type comes from PHPDoc). Not bumped here so the security fix lands clean; worth a separate look.
- **`phpunit/phpunit`** 11.5.56 → 13.2.6 — major. Blocked by 27 pre-existing doc-comment metadata deprecations in the
  test suite, which PHPUnit 12 drops support for.

## Verification

- `composer test` — 78 tests, 245 assertions, green
- `composer analyse` — no errors
- `composer audit` — no advisories found
- Confirmed `eval()` is gone from `is_falsy()` in the installed WPCS 3.4.1